### PR TITLE
Expose and document exception classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,9 @@ target/
 #pycharm
 .idea/*
 
+#vscode
+.vscode
+
 
 #Ipython Notebook
 .ipynb_checkpoints

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -112,7 +112,20 @@ Memento API. We implement a Python client that can speak both.
 
     .. automethod:: reset
 
-Utility functions
+Utility Functions
 -----------------
 
 .. autofunction:: wayback.memento_url_data
+
+Exception Classes
+-----------------
+
+.. autoclass:: wayback.exceptions.WaybackException
+
+.. autoclass:: wayback.exceptions.UnexpectedResponseFormat
+
+.. autoclass:: wayback.exceptions.BlockedByRobotsError
+
+.. autoclass:: wayback.exceptions.MementoPlaybackError
+
+.. autoclass:: wayback.exceptions.WaybackRetryError

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -18,57 +18,27 @@ from collections import namedtuple
 from datetime import datetime, timezone
 import hashlib
 import logging
-import urllib.parse
 import re
-import time
-from . import _utils, __version__
-
 import requests
+from requests.exceptions import (ConnectionError,
+                                 ProxyError,
+                                 RetryError,
+                                 Timeout)
+import time
+import urllib.parse
 from urllib3.connectionpool import HTTPConnectionPool
-from requests.exceptions import (
-    ConnectionError,
-    ProxyError,
-    RetryError,
-    Timeout
-)
-from urllib3.exceptions import (
-    ConnectTimeoutError,
-    MaxRetryError,
-    ReadTimeoutError
-)
+from urllib3.exceptions import (ConnectTimeoutError,
+                                MaxRetryError,
+                                ReadTimeoutError)
+from . import _utils, __version__
+from .exceptions import (WaybackException,
+                         UnexpectedResponseFormat,
+                         BlockedByRobotsError,
+                         MementoPlaybackError,
+                         WaybackRetryError)
 
 
 logger = logging.getLogger(__name__)
-
-
-class WaybackException(Exception):
-    # All exceptions raised directly by this package inherit from this.
-    ...
-
-
-class UnexpectedResponseFormat(WaybackException):
-    ...
-
-
-class BlockedByRobotsError(WaybackException):
-    # A URL can't be queried in Wayback because it was blocked by robots.txt
-    ...
-
-
-# TODO: split this up into a family of more specific errors? When playback
-# failed partway into a redirect chain, when a redirect goes outside
-# redirect_target_window, when a memento was circular?
-class MementoPlaybackError(WaybackException):
-    ...
-
-
-class WaybackRetryError(WaybackException):
-    def __init__(self, retries, total_time, causal_error):
-        self.retries = retries
-        self.cause = causal_error
-        self.time = total_time
-        super().__init__(f'Retried {retries} times over {total_time or "?"} seconds (error: {causal_error})')
-
 
 CDX_SEARCH_URL = 'http://web.archive.org/cdx/search/cdx'
 # This /web/timemap URL has newer features, but has other bugs and doesn't

--- a/wayback/exceptions.py
+++ b/wayback/exceptions.py
@@ -1,0 +1,55 @@
+"""
+Exception classes that may be raised from the Wayback package.
+"""
+
+
+class WaybackException(Exception):
+    "Base exception class for all Wayback-specific errors."
+
+
+class UnexpectedResponseFormat(WaybackException):
+    """
+    Raised when data returned by the Wayback Machine is formatted in an
+    unexpected or unparseable way.
+    """
+
+
+class BlockedByRobotsError(WaybackException):
+    """
+    Raised when a URL can't be queried in Wayback because it was blocked by a
+    site's `robots.txt` file.
+    """
+
+
+# TODO: split this up into a family of more specific errors? When playback
+# failed partway into a redirect chain, when a redirect goes outside
+# redirect_target_window, when a memento was circular?
+class MementoPlaybackError(WaybackException):
+    """
+    Raised when a Memento can't be 'played back' (loaded) by the Wayback
+    Machine for some reason. This is a server-side issue, not a problem in
+    parsing data from Wayback.
+    """
+
+
+class WaybackRetryError(WaybackException):
+    """
+    Raised when a request to the Wayback Machine has been retried and failed
+    too many times. The number of tries before this exception is raised
+    generally depends on your `WaybackSession` settings.
+
+    Attributes
+    ----------
+    retries : int
+        The number of retries that were attempted.
+    cause : Exception
+        The actual, underlying error that would have caused a retry.
+    time : int
+        The total time spent across all retried requests, in seconds.
+    """
+
+    def __init__(self, retries, total_time, causal_error):
+        self.retries = retries
+        self.cause = causal_error
+        self.time = total_time
+        super().__init__(f'Retried {retries} times over {total_time or "?"} seconds (error: {causal_error})')

--- a/wayback/tests/test_client.py
+++ b/wayback/tests/test_client.py
@@ -5,8 +5,8 @@ import vcr
 from .._utils import SessionClosedError
 from .._client import (WaybackSession,
                        WaybackClient,
-                       original_url_for_memento,
-                       MementoPlaybackError)
+                       original_url_for_memento)
+from ..exceptions import MementoPlaybackError
 
 
 # This stashes HTTP responses in JSON files (one per test) so that an actual


### PR DESCRIPTION
Move all our exception classes to `wayback.exceptions` and document them so they can easily be used.

This seems like a fairly common pattern in the Python packaging world, but if there’s a better way to structure our exceptions for both internal *and* external use, I’m happy to adjust! Also open to renaming this module and the base exception to `error` or whatever else while we are cleaning up exception-y things.