### PR TITLE
Remove vestigial bits from `_utils` module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-lxml
 requests
 urllib3

--- a/wayback/_utils.py
+++ b/wayback/_utils.py
@@ -1,14 +1,10 @@
 from collections import defaultdict
 from contextlib import contextmanager
-import logging
 import requests
 import requests.adapters
 import threading
 import time
 from .exceptions import SessionClosedError
-
-
-logger = logging.getLogger(__name__)
 
 
 _last_call_by_group = defaultdict(int)

--- a/wayback/_utils.py
+++ b/wayback/_utils.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from contextlib import contextmanager
-import hashlib
 import logging
 import os
 import queue
@@ -13,11 +12,6 @@ import requests.adapters
 
 
 logger = logging.getLogger(__name__)
-
-
-def hash_content(content_bytes):
-    "Create a version_hash for the content of a snapshot."
-    return hashlib.sha256(content_bytes).hexdigest()
 
 
 _last_call_by_group = defaultdict(int)

--- a/wayback/_utils.py
+++ b/wayback/_utils.py
@@ -1,40 +1,18 @@
 from collections import defaultdict
 from contextlib import contextmanager
 import hashlib
-import io
 import logging
 import os
 import queue
-import re
 import signal
 import threading
 import time
 
-import lxml.html
 import requests
 import requests.adapters
 
 
 logger = logging.getLogger(__name__)
-
-WHITESPACE_PATTERN = re.compile(r'\s+')
-
-
-def extract_title(content_bytes, encoding='utf-8'):
-    "Return content of <title> tag as string. On failure return empty string."
-    content_str = content_bytes.decode(encoding=encoding, errors='ignore')
-    # The parser expects a file-like, so we mock one.
-    content_as_file = io.StringIO(content_str)
-    try:
-        title = lxml.html.parse(content_as_file).find(".//title")
-    except Exception:
-        return ''
-
-    if title is None or title.text is None:
-        return ''
-
-    # In HTML, all consecutive whitespace (including line breaks) collapses
-    return WHITESPACE_PATTERN.sub(' ', title.text.strip())
 
 
 def hash_content(content_bytes):

--- a/wayback/_utils.py
+++ b/wayback/_utils.py
@@ -46,23 +46,6 @@ def rate_limited(calls_per_second=2, group='default'):
         yield
 
 
-def get_color_palette():
-    """
-    Read and return the CSS color env variables that indicate the colors in
-    html_diff_render, differs and links_diff.
-
-    Returns
-    ------
-    palette: Dictionary
-        A dictionary containing the differ_insertion and differ_deletion css
-        color codes
-    """
-    differ_insertion = os.environ.get('DIFFER_COLOR_INSERTION', '#a1d76a')
-    differ_deletion = os.environ.get('DIFFER_COLOR_DELETION', '#e8a4c8')
-    return {'differ_insertion': differ_insertion,
-            'differ_deletion': differ_deletion}
-
-
 def iterate_into_queue(queue, iterable):
     """
     Read items from an iterable and place them onto a FiniteQueue.

--- a/wayback/_utils.py
+++ b/wayback/_utils.py
@@ -1,11 +1,11 @@
 from collections import defaultdict
 from contextlib import contextmanager
 import logging
-import threading
-import time
-
 import requests
 import requests.adapters
+import threading
+import time
+from .exceptions import SessionClosedError
 
 
 logger = logging.getLogger(__name__)
@@ -75,10 +75,6 @@ class DepthCountedContext:
         overridden in your class.
         """
         pass
-
-
-class SessionClosedError(Exception):
-    ...
 
 
 class DisableAfterCloseSession(requests.Session):

--- a/wayback/exceptions.py
+++ b/wayback/exceptions.py
@@ -53,3 +53,10 @@ class WaybackRetryError(WaybackException):
         self.cause = causal_error
         self.time = total_time
         super().__init__(f'Retried {retries} times over {total_time or "?"} seconds (error: {causal_error})')
+
+
+class SessionClosedError(Exception):
+    """
+    Raised when a Wayback session is used to make a request after it has been
+    closed and disabled.
+    """


### PR DESCRIPTION
We had a whole bunch of vestigial bits in the `_utils` module that were left over from web-monitoring-processing but not used here. This removes them and also removes the `lxml` dependency, which was only present because of a vestigial utility function.

While I was at it, I also moved the `SessionClosedError` class to the `exceptions` module, since I completely missed it in #7.