### PR TITLE
Explicitly close response when search is done.

### DIFF
--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -541,7 +541,8 @@ class WaybackClient(_utils.DepthCountedContext):
         except requests.exceptions.HTTPError as error:
             raise WaybackException(str(error))
 
-        lines = response.iter_lines()
+        lines = iter(response.content.splitlines())
+        response.close()
         count = 0
 
         for line in lines:


### PR DESCRIPTION
The response would evenutally be closed by garbage collection, but it is
better to close it explicitly. When requests are issued at a high rate,
this makes a significant difference.