### PR TITLE
Release connections for memento redirects

### DIFF
--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -731,8 +731,14 @@ class WaybackClient(_utils.DepthCountedContext):
 
                 if response.next:
                     previous_was_memento = is_memento
-                    urls.add(response.url)
+
+                    # Read content so it gets cached and close the response so
+                    # we can release the connection for reuse.
+                    response.content
+                    response.close()
+
                     # Wayback sometimes has circular memento redirects ¯\_(ツ)_/¯
+                    urls.add(response.url)
                     if response.next.url in urls:
                         raise MementoPlaybackError(f'Memento at {url} is circular')
 


### PR DESCRIPTION
When we handle memento redirects, we should have been loading all the content and then closing the response so that the connection is released for re-use, otherwise it just gets left hanging around :(

This contributes to solving some of the issues over in edgi-govdata-archiving/web-monitoring-processing#525