### PR TITLE
Make sure to close responses where they may leak

### DIFF
--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -223,7 +223,8 @@ def read_and_close(response):
         response.content
     except (ChunkedEncodingError, ContentDecodingError, RuntimeError):
         response.raw.read(decode_content=False)
-    response.close()
+    finally:
+        response.close()
 
 
 #####################################################################


### PR DESCRIPTION
This is a bit of a follow-on to #19 and #20.

These are all the remaining places I could find possible connection leaks from responses being held onto. A lot of these cases *should* be covered by the requests library (it takes a similar approach and caches response bodies before raising most exceptions), but I didn't feel like I could be certain that was always true, so I went with the most cautious approach: anywhere we aren't explicitly returning an open request, read/cache the body and close it.