### PR TITLE
Support Python 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  test-3.7: &test-template
     working_directory: ~/wayback
     docker:
       - image: circleci/python:3.7
@@ -45,8 +45,14 @@ jobs:
             . ~/venv/bin/activate
             make -C docs html
 
+  test-3.6:
+    <<: test-template
+    docker:
+      - image: circleci/python:3.6
+
 workflows:
   version: 2
   build:
     jobs:
-      - build
+      - test-3.6
+      - test-3.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
             make -C docs html
 
   test-3.6:
-    <<: test-template
+    <<: *test-template
     docker:
       - image: circleci/python:3.6
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import versioneer
 # NOTE: This file must remain Python 2 compatible for the foreseeable future,
 # to ensure that we error out properly for people with outdated setuptools
 # and/or pip.
-min_version = (3, 7)
+min_version = (3, 6)
 if sys.version_info < min_version:
     error = """
 wayback does not support Python {0}.{1}.


### PR DESCRIPTION
This commit relaxes the setup.py to allow for python 3.6, which still passes the test suite. I also took a shot at updating the circleci setup to test 3.6, but I'm not 100% sure I did that correctly or that it works.

Fixes #27 