### PR TITLE
Add colon between parameter names & types in docs

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -1,0 +1,12 @@
+/*
+   Sphinx v2 and sphinx_rtd_theme are not *quite* compatible. The markup output
+   for definition lists in Sphinx 2 is slightly different, and requires a theme
+   to add separators between terms (which are function parameter names in most
+   cases) and their classifiers (the parameter's types, like `date`).
+
+   For more, see:
+   https://github.com/edgi-govdata-archiving/web-monitoring-processing/issues/468#issuecomment-538532324
+*/
+.classifier::before {
+    content: ": ";
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,6 +114,12 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# These paths are either relative to html_static_path
+# or fully qualified paths (eg. https://...)
+html_css_files = [
+    'css/custom.css',
+]
+
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #


### PR DESCRIPTION
Makes the parameter names in our docs readable again my adding a colon between the parameter names and types. The fix here is really exactly the same as edgi-govdata-archiving/web-monitoring-processing#489.

Fixes #16.