### PR TITLE
Update docs links in README to use readthedocs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,9 @@ wayback
 Python API to Internet Archive Wayback Machine
 
 * Free software: 3-clause BSD license
-* Documentation: (COMING SOON!) https://edgi-govdata-archiving.github.io/wayback.
+* Documentation:
+    * Current Release: https://wayback.readthedocs.io/en/stable/
+    * Development: https://wayback.readthedocs.io/en/latest/
 
 
 Features


### PR DESCRIPTION
Pretty much just what it says: updates the documentation link(s) in the README to point to readthedocs.org.