### PR TITLE
Only include mementos in `history`

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -5,7 +5,9 @@ Release History
 In Development
 --------------
 
-Updates slated for the next release: [TBD]
+Updates slated for the next release:
+
+- The ``history`` attribute of a memento now only includes redirects that were mementos (i.e. redirects that would have been seen when browsing the recorded site at the time it was recorded). Other redirects involved in working with the memento API are still available in ``debug_history``, which includes all redirects, whether or not they were mementos.
 
 
 v0.2.3 (2020-03-25)

--- a/wayback/tests/test_client.py
+++ b/wayback/tests/test_client.py
@@ -136,7 +136,8 @@ def test_get_memento_with_redirects():
     with WaybackClient() as client:
         response = client.get_memento(
             'http://web.archive.org/web/20180808094144id_/https://www.epa.gov/ghgreporting/san5779-factsheet')
-        assert len(response.history) == 2  # redirects
+        assert len(response.history) == 1        # memento redirects
+        assert len(response.debug_history) == 2  # actual HTTP redirects
 
 
 @ia_vcr.use_cassette()


### PR DESCRIPTION
A memento’s `history` attribute now only lists the redirects that were mementos (i.e. redirects that would have been seen when browsing the recorded site at the time it was recorded). Other redirects involved in working with the memento API are still available in `debug_history`, which includes all redirects, whether they were mementos or not.

Fixes #36.