### PR TITLE
Filter out repeat results from `WaybackClient.search`

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -9,6 +9,8 @@ Updates slated for the next release:
 
 - The ``history`` attribute of a memento now only includes redirects that were mementos (i.e. redirects that would have been seen when browsing the recorded site at the time it was recorded). Other redirects involved in working with the memento API are still available in ``debug_history``, which includes all redirects, whether or not they were mementos.
 
+- Wayback’s CDX search API sometimes returns repeated, identical results. These are now filtered out, so repeat search results will not be yielded from :meth:`wayback.WaybackClient.search`.
+
 
 v0.2.3 (2020-03-25)
 -------------------

--- a/wayback/tests/cassettes/test_search_does_not_repeat_results
+++ b/wayback/tests/cassettes/test_search_does_not_repeat_results
@@ -1,0 +1,45 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - wayback/0.2.3.post3.dev0+g5a994c7 (+https://github.com/edgi-govdata-archiving/wayback)
+    method: GET
+    uri: http://web.archive.org/cdx/search/cdx?url=energystar.gov%2F&from=20200612000000&to=20200613000000&showResumeKey=true&resolveRevisits=true
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAM3UQUvDMBQH8Ps+Ra6CLi/vJen01rlClVJcqNbuNqR0A3XShla/vekuA8HsEsru
+        CT/+7/15zaG/rj/rtvnp7La94gwBAbRAEBIgYjtrv+44Pz2ZN4eeM1t/W76zH++MQLA0y42Oy5ey
+        un+mKk7yitIqzR6e8jLX+jViknDWXIYk5FHqHDUMw/wvN2zbN97W/b7bW3bDVsuYcqnkxmwkrpNl
+        YtTaFES4eiyKzCimQV+Qp4WSFGyS5JcUBk6m/veEm6PQU3RklDB0ssjjoVpM0/5RCt5G386UjDDc
+        zjxtHCWi6XZ2LMmt1zvFc1/Ocy6AZ5LOW1BoT3g8QhIQ0vMWZeQw3NmC2S9DoXwg1QYAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Date:
+      - Wed, 17 Jun 2020 16:24:27 GMT
+      Server:
+      - nginx/1.15.8
+      Transfer-Encoding:
+      - chunked
+      X-App-Server:
+      - wwwb-app15
+      X-Cache-Key:
+      - httpweb.archive.org/cdx/search/cdx?url=energystar.gov%2F&from=20200612000000&to=20200613000000&showResumeKey=true&resolveRevisits=trueUS
+      X-Page-Cache:
+      - BYPASS
+      X-location:
+      - cdx
+      X-ts:
+      - '200'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/wayback/tests/test_client.py
+++ b/wayback/tests/test_client.py
@@ -88,6 +88,18 @@ def test_search_cannot_iterate_after_session_closing():
         next(versions)
 
 
+@ia_vcr.use_cassette()
+def test_search_does_not_repeat_results():
+    with WaybackClient() as client:
+        versions = client.search('energystar.gov/',
+                                 from_date=datetime(2020, 6, 12),
+                                 to_date=datetime(2020, 6, 13))
+        previous = None
+        for version in versions:
+            assert version != previous
+            previous = version
+
+
 class TestOriginalUrlForMemento:
     def test_extracts_url(self):
         url = original_url_for_memento(


### PR DESCRIPTION
The CDX API sometimes returns repeat results (most likely because save-page-now is being so heavily used that two copies were really being saved at the same time, but we have not been able to get a clear answer on causes from the Wayback team yet). Since there's no useful way to get information about the two mementos with identical CDX records (assuming there actually are two, and there's not a CDX problem), this simply filters out the repeats so users don't have to worry about handling them properly.

Fixes #40.