### PR TITLE
Include tzinfo in CDX search results

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -9,6 +9,8 @@ Updates slated for the next release:
 
 - The ``history`` attribute of a memento now only includes redirects that were mementos (i.e. redirects that would have been seen when browsing the recorded site at the time it was recorded). Other redirects involved in working with the memento API are still available in ``debug_history``, which includes all redirects, whether or not they were mementos.
 
+- The timestamps in ``CdxRecord`` objects returned by ``WaybackClient.search()`` now include timezone information. (They are always in the UTC timezone.)
+
 
 v0.2.3 (2020-03-25)
 -------------------

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -5,11 +5,13 @@ Release History
 In Development
 --------------
 
-Updates slated for the next release:
+**Breaking changes** slated for the next release:
+
+- The timestamps in ``CdxRecord`` objects returned by :meth:`wayback.WaybackClient.search` now include timezone information. (They are always in the UTC timezone.)
+
+**Updates** slated for the next release:
 
 - The ``history`` attribute of a memento now only includes redirects that were mementos (i.e. redirects that would have been seen when browsing the recorded site at the time it was recorded). Other redirects involved in working with the memento API are still available in ``debug_history``, which includes all redirects, whether or not they were mementos.
-
-- The timestamps in ``CdxRecord`` objects returned by ``WaybackClient.search()`` now include timezone information. (They are always in the UTC timezone.)
 
 
 v0.2.3 (2020-03-25)

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -589,8 +589,9 @@ class WaybackClient(_utils.DepthCountedContext):
                 else:
                     status_code = int(data.status_code)
                 length = int(data.length)
-                capture_time = datetime.strptime(data.timestamp,
-                                                 URL_DATE_FORMAT)
+                capture_time = (datetime.strptime(data.timestamp,
+                                                  URL_DATE_FORMAT)
+                                        .replace(tzinfo=timezone.utc))
             except Exception as err:
                 if 'RobotAccessControlException' in text:
                     raise BlockedByRobotsError(query["url"])

--- a/wayback/tests/test_client.py
+++ b/wayback/tests/test_client.py
@@ -27,8 +27,8 @@ def test_search():
                                  from_date=datetime(1996, 10, 1),
                                  to_date=datetime(1997, 2, 1))
         for v in versions:
-            assert v.timestamp >= datetime(1996, 10, 1)
-            assert v.timestamp <= datetime(1997, 2, 1)
+            assert v.timestamp >= datetime(1996, 10, 1, tzinfo=timezone.utc)
+            assert v.timestamp <= datetime(1997, 2, 1, tzinfo=timezone.utc)
 
 
 @ia_vcr.use_cassette()
@@ -38,8 +38,8 @@ def test_search_with_date():
                                  from_date=date(2019, 10, 1),
                                  to_date=date(2020, 3, 1))
         for v in versions:
-            assert v.timestamp >= datetime(2019, 10, 1)
-            assert v.timestamp <= datetime(2020, 3, 1)
+            assert v.timestamp >= datetime(2019, 10, 1, tzinfo=timezone.utc)
+            assert v.timestamp <= datetime(2020, 3, 1, tzinfo=timezone.utc)
 
 
 @ia_vcr.use_cassette()
@@ -52,7 +52,8 @@ def test_search_with_timezone():
         versions = client.search('nasa.gov',
                                  from_date=t0)
         version = next(versions)
-        assert version.timestamp == datetime(1996, 12, 31, 23, 58, 47)
+        assert version.timestamp == datetime(1996, 12, 31, 23, 58, 47,
+                                             tzinfo=timezone.utc)
 
         # Search using UTC - 5, equivalent to (1997, 1, 1, 4, ...) in UTC
         # so that we miss the result above and expect a different, later one.
@@ -61,7 +62,8 @@ def test_search_with_timezone():
         versions = client.search('nasa.gov',
                                  from_date=t0)
         version = next(versions)
-        assert version.timestamp == datetime(1997, 6, 5, 23, 5, 59)
+        assert version.timestamp == datetime(1997, 6, 5, 23, 5, 59,
+                                             tzinfo=timezone.utc)
 
 
 @ia_vcr.use_cassette()


### PR DESCRIPTION
This is a breaking API change, but is intended to make our output data more clear. Fixes #39.