### PR TITLE
Use CircleCI matrix configuration syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,13 @@
-version: 2
+version: 2.1
 jobs:
-  test-3.7: &test-template
+  test:
+    parameters:
+      python-version:
+        type: string
+
     working_directory: ~/wayback
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:<< parameters.python-version >>
     steps:
       - checkout
       - restore_cache:
@@ -45,14 +49,10 @@ jobs:
             . ~/venv/bin/activate
             make -C docs html
 
-  test-3.6:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.6
-
 workflows:
-  version: 2
   build:
     jobs:
-      - test-3.6
-      - test-3.7
+      - test:
+          matrix:
+            parameters:
+              python-version: ["3.6", "3.7"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: cache_v3-wayback-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+          key: cache_v3-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
 
       # Bundle install dependencies
       - run:
@@ -24,7 +24,7 @@ jobs:
 
       # Store bundle cache
       - save_cache:
-          key: cache_v3-wayback-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+          key: cache_v3-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
           paths:
             - ~/venv
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,11 @@ jobs:
 
     working_directory: ~/wayback
     docker:
-      - image: circleci/python:<< parameters.python-version >>
+      - image: cimg/python:<< parameters.python-version >>
     steps:
       - checkout
       - restore_cache:
-          key: cache_v2-wayback-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+          key: cache_v3-wayback-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
 
       # Bundle install dependencies
       - run:
@@ -24,7 +24,7 @@ jobs:
 
       # Store bundle cache
       - save_cache:
-          key: cache_v2-wayback-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+          key: cache_v3-wayback-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
           paths:
             - ~/venv
 


### PR DESCRIPTION
We were using YAML anchors and references to run tests against multiple Python versions, but CircleCI recently added a specialized “matrix” syntax for doing this kind of thing in a nicer and more powerful way. This updates to that new syntax.