### PR TITLE
Raise `RateLimitError` for 429 responses

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -15,6 +15,8 @@ In Development
 
 - Wayback’s CDX search API sometimes returns repeated, identical results. These are now filtered out, so repeat search results will not be yielded from :meth:`wayback.WaybackClient.search`.
 
+- :class:`wayback.exceptions.RateLimitError` will now be raised as an exception any time you breach the Wayback Machine's rate limits. This would previously have been :class:`wayback.exceptions.WaybackException`, :class:`wayback.exceptions.MementoPlaybackError`, or regular HTTP responses, depending on the method you called.
+
 
 v0.2.3 (2020-03-25)
 -------------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -128,4 +128,8 @@ Exception Classes
 
 .. autoclass:: wayback.exceptions.MementoPlaybackError
 
+.. autoclass:: wayback.exceptions.RateLimitError
+
 .. autoclass:: wayback.exceptions.WaybackRetryError
+
+.. autoclass:: wayback.exceptions.SessionClosedError

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -37,7 +37,8 @@ from .exceptions import (WaybackException,
                          UnexpectedResponseFormat,
                          BlockedByRobotsError,
                          MementoPlaybackError,
-                         WaybackRetryError)
+                         WaybackRetryError,
+                         RateLimitError)
 
 
 logger = logging.getLogger(__name__)
@@ -336,6 +337,8 @@ class WaybackSession(_utils.DisableAfterCloseSession, requests.Session):
             try:
                 result = super().send(*args, **kwargs)
                 if retries >= maximum or not self.should_retry(result):
+                    if result.status_code == 429:
+                        raise RateLimitError(result)
                     return result
             except WaybackSession.handleable_errors as error:
                 response = getattr(error, 'response', None)


### PR DESCRIPTION
Status code 429 ("Too Many Requests") specifies that you've hit a rate limit, and the Wayback Machine makes good use of it. We now raise a special error type for this case since it's something a user might want to have special handling for.

Fixes #22.