### PR TITLE
Split CircleCI work into several jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,8 @@ commands:
           command: |
             python -m venv ~/venv
             . ~/venv/bin/activate
+            # Ensure pip is up-to-date
+            pip install --upgrade pip
             pip install .
             pip install -r requirements-dev.txt  # extra requirements for tests, docs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ version: 2.1
 commands:
   setup_pip:
     description: "Set Up Dependencies"
+    parameters:
+      python-version:
+        type: string
     steps:
       - restore_cache:
           keys:
@@ -28,12 +31,14 @@ jobs:
     parameters:
       python-version:
         type: string
+
     working_directory: ~/wayback
     docker:
       - image: cimg/python:<< parameters.python-version >>
     steps:
       - checkout
-      - setup_pip
+      - setup_pip:
+          python-version: << parameters.python-version >>
 
       - run:
           name: Tests
@@ -52,7 +57,8 @@ jobs:
       - image: cimg/python:3.8
     steps:
       - checkout
-      - setup_pip
+      - setup_pip:
+          python-version: "3.8"
       - run:
           name: Code linting
           command: |
@@ -65,7 +71,8 @@ jobs:
       - image: cimg/python:3.8
     steps:
       - checkout
-      - setup_pip
+      - setup_pip:
+          python-version: "3.8"
       - run:
           name: Build Distribution
           command: |
@@ -86,7 +93,8 @@ jobs:
   #     - image: cimg/python:3.8
   #   steps:
   #     - checkout
-  #     - setup_pip
+  #     - setup_pip:
+  #         python-version: "3.8"
   #     - run:
   #         name: Build docs
   #         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,21 +87,24 @@ jobs:
             twine check dist/*
             check-wheel-contents --toplevel wayback dist
 
-  # NOTE: We currently build docs on Travis, so this isn't relevant.
-  # This job is here for reference.
-  # docs:
-  #   working_directory: ~/wayback
-  #   docker:
-  #     - image: cimg/python:3.8
-  #   steps:
-  #     - checkout
-  #     - setup_pip:
-  #         python-version: "3.8"
-  #     - run:
-  #         name: Build docs
-  #         command: |
-  #           . ~/venv/bin/activate
-  #           make -C docs html
+  # NOTE: The docs are mainly built and published directly by readthedocs.com.
+  # This job is meant to verify there are no issues with the docs and it is NOT
+  # responsible for building what actually gets published. (Readthedocs.com
+  # builds with rather loose error handling, and does not fail even when there
+  # may be significant issues.)
+  docs:
+    working_directory: ~/wayback
+    docker:
+      - image: cimg/python:3.8
+    steps:
+      - checkout
+      - setup_pip:
+          python-version: "3.8"
+      - run:
+          name: Build docs
+          command: |
+            . ~/venv/bin/activate
+            make -C docs html
 
 workflows:
   build:
@@ -112,3 +115,4 @@ workflows:
               python-version: ["3.6", "3.7", "3.8"]
       - lint
       - build
+      - docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,15 @@
 version: 2.1
-jobs:
-  test:
-    parameters:
-      python-version:
-        type: string
 
-    working_directory: ~/wayback
-    docker:
-      - image: cimg/python:<< parameters.python-version >>
+commands:
+  setup_pip:
+    description: "Set Up Dependencies"
     steps:
-      - checkout
       - restore_cache:
-          key: cache_v4-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+          keys:
+            - cache_v4-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            - cache_v4-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-
+            - cache_v4-wayback-<< parameters.python-version >>-{{ arch }}-
 
-      # Bundle install dependencies
       - run:
           name: Install Dependencies
           command: |
@@ -22,11 +18,22 @@ jobs:
             pip install .
             pip install -r requirements-dev.txt  # extra requirements for tests, docs
 
-      # Store bundle cache
       - save_cache:
           key: cache_v4-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
           paths:
             - ~/venv
+
+jobs:
+  test:
+    parameters:
+      python-version:
+        type: string
+    working_directory: ~/wayback
+    docker:
+      - image: cimg/python:<< parameters.python-version >>
+    steps:
+      - checkout
+      - setup_pip
 
       - run:
           name: Tests
@@ -38,16 +45,53 @@ jobs:
           command: |
             . ~/venv/bin/activate
             coverage report -m
+
+  lint:
+    working_directory: ~/wayback
+    docker:
+      - image: cimg/python:3.8
+    steps:
+      - checkout
+      - setup_pip
       - run:
           name: Code linting
           command: |
             . ~/venv/bin/activate
             flake8 .
+
+  build:
+    working_directory: ~/wayback
+    docker:
+      - image: cimg/python:3.8
+    steps:
+      - checkout
+      - setup_pip
       - run:
-          name: Build docs
+          name: Build Distribution
           command: |
             . ~/venv/bin/activate
-            make -C docs html
+            python setup.py sdist bdist_wheel
+      - run:
+          name: Check Distribution
+          command: |
+            . ~/venv/bin/activate
+            twine check dist/*
+            check-wheel-contents --toplevel wayback dist
+
+  # NOTE: We currently build docs on Travis, so this isn't relevant.
+  # This job is here for reference.
+  # docs:
+  #   working_directory: ~/wayback
+  #   docker:
+  #     - image: cimg/python:3.8
+  #   steps:
+  #     - checkout
+  #     - setup_pip
+  #     - run:
+  #         name: Build docs
+  #         command: |
+  #           . ~/venv/bin/activate
+  #           make -C docs html
 
 workflows:
   build:
@@ -55,4 +99,6 @@ workflows:
       - test:
           matrix:
             parameters:
-              python-version: ["3.6", "3.7"]
+              python-version: ["3.6", "3.7", "3.8"]
+      - lint
+      - build

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,6 @@ Wayback is a Python client to the Internet Archive Wayback Machine.
 .. toctree::
    :maxdepth: 2
 
-   installation
+   installations
    usage
    release-history

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,6 @@ Wayback is a Python client to the Internet Archive Wayback Machine.
 .. toctree::
    :maxdepth: 2
 
-   installations
+   installation
    usage
    release-history

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 # These are required for developing the package (running the tests, building
 # the documentation) but not necessarily required for _using_ it.
+check-wheel-contents ~=0.1.0
 codecov
 coverage
 flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 # These are required for developing the package (running the tests, building
 # the documentation) but not necessarily required for _using_ it.
+wheel
 check-wheel-contents ~=0.1.0
 codecov
 coverage
@@ -8,6 +9,7 @@ requests-mock
 pytest
 sphinx ~=3.1.1
 vcrpy
+twine
 # These are dependencies of various sphinx extensions for documentation.
 ipython
 numpydoc ~=1.0.0


### PR DESCRIPTION
We currently have one massive job for all the checks we do on a PR, which a) prevents us from seeing all the errors (since it stops at the first error) and b) means we execute things like linting and docs once for each Python version, when they really only need to run once (unlike tests). This splits the jobs into:

- test (runs tests and coverage)
- lint
- build (this is new! Builds and checks the package)
- docs (doesn't actually run, since we really build our docs on Travis. No reason to waste the effort in Circle.)