### PR TITLE
Improve docs and contrast with “internetarchive” package

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,6 +5,9 @@ Contributing
 Contributions are welcome, and they are greatly appreciated! Every
 little bit helps, and credit will always be given.
 
+Before contributing, please be sure to take a look at our
+`code of conduct <https://github.com/edgi-govdata-archiving/overview/blob/main/CONDUCT.md>`_.
+
 You can contribute in many ways:
 
 Types of Contributions

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Finally, search for all the mementos of ``nasa.gov`` before 1999 and download th
 
 .. code-block:: python
 
-    for record in client.search('http://nasa.gov', to_date='19990101'):
+    for record in client.search('http://nasa.gov', to_date=date(1999, 1, 1)):
         memento = client.get_memento(record.raw_url)
 
 Read the `full documentation <https://wayback.readthedocs.io/>`_ for a more in-depth tutorial and complete API reference documentation at https://wayback.readthedocs.io/

--- a/README.rst
+++ b/README.rst
@@ -19,9 +19,9 @@ wayback
         :alt: Documentation Status
 
 
-*Wayback* is A Python API to the Internet Archive’s Wayback Machine. It gives you tools to search for and load mementos (captured historical copies of web pages).
+*Wayback* is A Python API to the `Internet Archive’s Wayback Machine <https://web.archive.org/>`_. It gives you tools to search for and load mementos (historical copies of web pages).
 
-Hows does this differ from the official `“internetarchive” <https://archive.org/services/docs/api/internetarchive/>`_ Python package? The internetarchive package is mainly concerned with the APIs and tools that manage the Internet Archive as a whole: managing items and collections. These are how e-books, audio recordings, movies, and other content in the Internet Archive are managed. It doesn’t, however, provide particularly good tools for finding or loading historical captures of specific URLs (i.e. the part of the Internet Archive called the “Wayback Machine”). That’s what this package does.
+The Internet Archive maintains an official `“internetarchive” <https://archive.org/services/docs/api/internetarchive/>`_ Python package, but it does not focus on the Wayback Machine. Instead, it is mainly concerned with the APIs and tools that manage the Internet Archive as a whole: managing items and collections. These are how e-books, audio recordings, movies, and other content in the Internet Archive are managed. It doesn’t, however, provide particularly good tools for finding or loading historical captures of specific URLs (i.e. the part of the Internet Archive called the “Wayback Machine”). That’s what this package does.
 
 * Documentation:
     * Current Release: https://wayback.readthedocs.io/en/stable/
@@ -58,7 +58,7 @@ Code of Conduct
 This repository falls under EDGI’s `Code of Conduct <https://github.com/edgi-govdata-archiving/overview/blob/main/CONDUCT.md>`_. Pleas take a moment to review it before commenting on or creating issues and pull requests.
 
 
-Contributing
+Contributors
 ------------
 
 Thanks to the following people for their contributions and help on this package! See our `contributing guidelines <https://github.com/edgi-govdata-archiving/wayback/blob/main/CONTRIBUTING.rst>`_ to find out how you can help.

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 wayback
 ===============================
 
-.. image:: https://circleci.com/gh/edgi-govdata-archiving/wayback.svg?style=svg
+.. image:: https://circleci.com/gh/edgi-govdata-archiving/wayback/tree/main.svg?style=shield
         :target: https://circleci.com/gh/edgi-govdata-archiving/wayback
 
 .. image:: https://img.shields.io/pypi/v/wayback.svg

--- a/README.rst
+++ b/README.rst
@@ -4,12 +4,19 @@ wayback
 
 .. image:: https://circleci.com/gh/edgi-govdata-archiving/wayback/tree/main.svg?style=shield
         :target: https://circleci.com/gh/edgi-govdata-archiving/wayback
+        :alt: Build Status
 
 .. image:: https://img.shields.io/pypi/v/wayback.svg
         :target: https://pypi.python.org/pypi/wayback
+        :alt: Download Latest Version from PyPI
 
 .. image:: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat
         :target: https://github.com/edgi-govdata-archiving/overview/blob/main/CONDUCT.md
+        :alt: Code of Conduct
+
+.. image:: https://readthedocs.org/projects/wayback/badge/?version=stable
+        :target: https://wayback.readthedocs.io/en/stable/?badge=stable
+        :alt: Documentation Status
 
 
 *Wayback* is A Python API to the Internet Archive’s Wayback Machine. It gives you tools to search for and load mementos (captured historical copies of web pages).

--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,14 @@
 wayback
 ===============================
 
-.. image:: https://img.shields.io/travis/edgi-govdata-archiving/wayback.svg
-        :target: https://travis-ci.org/edgi-govdata-archiving/wayback
+.. image:: https://circleci.com/gh/edgi-govdata-archiving/wayback.svg?style=svg
+        :target: https://circleci.com/gh/edgi-govdata-archiving/wayback
 
 .. image:: https://img.shields.io/pypi/v/wayback.svg
         :target: https://pypi.python.org/pypi/wayback
+
+.. image:: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat
+        :target: https://github.com/edgi-govdata-archiving/overview/blob/main/CONDUCT.md
 
 
 *Wayback* is A Python API to the Internet Archive’s Wayback Machine. It gives you tools to search for and load mementos (captured historical copies of web pages).
@@ -42,10 +45,16 @@ Finally, search for all the mementos of ``nasa.gov`` before 1999 and download th
 Read the `full documentation <https://wayback.readthedocs.io/>`_ for a more in-depth tutorial and complete API reference documentation at https://wayback.readthedocs.io/
 
 
-Contributors
+Code of Conduct
+---------------
+
+This repository falls under EDGI’s `Code of Conduct <https://github.com/edgi-govdata-archiving/overview/blob/main/CONDUCT.md>`_. Pleas take a moment to review it before commenting on or creating issues and pull requests.
+
+
+Contributing
 ------------
 
-Thanks to the following people for their contributions and help on this package! See our `contributing guidelines <https://github.com/edgi-govdata-archiving/wayback/blob/master/CONTRIBUTING.rst>`_ to find out how you can help.
+Thanks to the following people for their contributions and help on this package! See our `contributing guidelines <https://github.com/edgi-govdata-archiving/wayback/blob/main/CONTRIBUTING.rst>`_ to find out how you can help.
 
 - `Dan Allan <https://github.com/danielballan>`_ (Code, Tests, Documentation, Reviews)
 - `Rob Brackett <https://github.com/Mr0grog>`_ (Code, Tests, Documentation, Reviews)

--- a/README.rst
+++ b/README.rst
@@ -9,18 +9,37 @@ wayback
         :target: https://pypi.python.org/pypi/wayback
 
 
-Python API to Internet Archive Wayback Machine
+*Wayback* is A Python API to the Internet Archive’s Wayback Machine. It gives you tools to search for and load mementos (captured historical copies of web pages).
 
-* Free software: 3-clause BSD license
+Hows does this differ from the official `“internetarchive” <https://archive.org/services/docs/api/internetarchive/>`_ Python package? The internetarchive package is mainly concerned with the APIs and tools that manage the Internet Archive as a whole: managing items and collections. These are how e-books, audio recordings, movies, and other content in the Internet Archive are managed. It doesn’t, however, provide particularly good tools for finding or loading historical captures of specific URLs (i.e. the part of the Internet Archive called the “Wayback Machine”). That’s what this package does.
+
 * Documentation:
     * Current Release: https://wayback.readthedocs.io/en/stable/
     * Development: https://wayback.readthedocs.io/en/latest/
 
 
-Features
---------
+Installation & Basic Usage
+--------------------------
 
-* TODO
+Install via pip on the command line::
+
+    $ pip install wayback
+
+Then, in a Python script, import it and create a client:
+
+.. code-block:: python
+
+    import wayback
+    client = wayback.WaybackClient()
+
+Finally, search for all the mementos of ``nasa.gov`` before 1999 and download them:
+
+.. code-block:: python
+
+    for record in client.search('http://nasa.gov', to_date='19990101'):
+        memento = client.get_memento(record.raw_url)
+
+Read the `full documentation <https://wayback.readthedocs.io/>`_ for a more in-depth tutorial and complete API reference documentation at https://wayback.readthedocs.io/
 
 
 Contributors

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,12 +1,9 @@
-.. Packaging Scientific Python documentation master file, created by
-   sphinx-quickstart on Thu Jun 28 12:35:56 2018.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Wayback
 =======
 
-Wayback is a Python client to the Internet Archive Wayback Machine.
+*Wayback* is A Python API to the Internet Archive’s Wayback Machine. It gives you tools to search for and load mementos (captured historical copies of web pages).
+
+The Internet Archive has an official `“internetarchive” <https://archive.org/services/docs/api/internetarchive/>`_ package, but it is mainly concerned with the APIs and tools that manage the Internet Archive as a whole: managing items and collections. These are how e-books, audio recordings, movies, and other content are managed. It doesn’t, however, provide particularly good tools for finding or loading historical captures of specific URLs (i.e. the part of the Internet Archive called the “Wayback Machine”). That’s what the *wayback* package does.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,9 +1,9 @@
 Wayback
 =======
 
-*Wayback* is A Python API to the Internet Archive’s Wayback Machine. It gives you tools to search for and load mementos (captured historical copies of web pages).
+*Wayback* is A Python API to the `Internet Archive’s Wayback Machine <https://web.archive.org/>`_. It gives you tools to search for and load mementos (historical copies of web pages).
 
-The Internet Archive has an official `“internetarchive” <https://archive.org/services/docs/api/internetarchive/>`_ package, but it is mainly concerned with the APIs and tools that manage the Internet Archive as a whole: managing items and collections. These are how e-books, audio recordings, movies, and other content are managed. It doesn’t, however, provide particularly good tools for finding or loading historical captures of specific URLs (i.e. the part of the Internet Archive called the “Wayback Machine”). That’s what the *wayback* package does.
+The Internet Archive maintains an official `“internetarchive” <https://archive.org/services/docs/api/internetarchive/>`_ Python package, but it does not focus on the Wayback Machine. Instead, it is mainly concerned with the APIs and tools that manage the Internet Archive as a whole: managing items and collections. These are how e-books, audio recordings, movies, and other content in the Internet Archive are managed. It doesn’t, however, provide particularly good tools for finding or loading historical captures of specific URLs (i.e. the part of the Internet Archive called the “Wayback Machine”). That’s what the *wayback* package does.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -2,6 +2,6 @@
 Installation
 ============
 
-At the command line::
+Wayback is meant to be used as a Python library, and is best installed via *pip* on the command line::
 
     $ pip install wayback


### PR DESCRIPTION
This expands the description of the package and contrasts it with “internetarchive,” which this package might otherwise seem duplicative of. I’ve also tried to make a few other docs improvements while I was at it:

- Fix the build badge to point at Circle instead of Travis (since we aren’t building anything on Travis)
- Add some other appropriate badges.
- Add EDGI code of conduct links and info.
- Add some basic instructions to the README.

If you have a moment, would you mind taking a look, especially about the bits contrasting with the internetarchive package, @danielballan?

Fixes #13.