### PR TITLE
Return a new `Memento` type from `get_memento()`

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -74,6 +74,50 @@ In Development
 
 - :func:`wayback.memento_url_data` now returns 3 values instead of 2. The last value is a string representing the playback mode (see above description of the new ``mode`` parameter on :meth:`wayback.WaybackClient.get_memento` for more about playback modes).
 
+- :meth:`wayback.WaybackClient.get_memento` now returns a :class:`wayback.Memento` instance instead of a ``requests.Response`` object. It has a similar interface, but provides more useful information about the Memento than just the HTTP response from Wayback. For example, ``memento.url`` is the original URL the memento is a capture of (e.g. ``http://www.noaa.gov/``) rather than the Wayback URL (e.g. ``http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/``). You can still get the full Wayback URL from ``memento.memento_url``.
+
+  You can check out the full API docs for :class:`wayback.Memento`, but here’s a quick guide to what’s available:
+
+  .. code-block:: python
+
+     memento = client.get_memento('http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/home',
+                                  exact=False)
+
+     # These values were previously not available except by parsing
+     # `memento.url`. The old `memento.url` is now `memento.memento_url`.
+     memento.url == 'http://www.noaa.gov/'
+     memento.timestamp == datetime.datetime(2018, 8, 29, 8, 8, 49, tzinfo=timezone.utc)
+     memento.mode == 'id_'
+
+     # Used to be `memento.url`:
+     memento.memento_url == 'http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/'
+
+     # Used to be a list of `Response` objects, now a *tuple* of Mementos. It
+     # Still lists only the redirects that are actual Mementos and not part of
+     # Wayback's internal machinery:
+     memento.history == (Memento<url='http://noaa.gov/home'>,)
+
+     # Used to be a list of `Response` objects, now a *tuple* URL strings:
+     memento.debug_history == ('http://web.archive.org/web/20180816111911id_/http://noaa.gov/home',
+                               'http://web.archive.org/web/20180829092926id_/http://noaa.gov/home',
+                               'http://web.archive.org/web/20180829092926id_/http://noaa.gov/')
+
+     # Headers now only lists headers from the original, archived response, not
+     # additional headers from the Wayback Machine itself. (If there's
+     # important information you needed in the headers, file an issue and let
+     # us know! We'd like to surface that kind of information as attributes on
+     # the Memento now.
+     memento.headers = {'header_name': 'header_value',
+                        'another_header': 'another_value',
+                        'and': 'so on'}
+
+     # Same as before:
+     memento.status_code
+     memento.ok
+     memento.is_redirect
+     memento.encoding
+     memento.content
+     memento.text
 
 **New Features:**
 

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -9,119 +9,142 @@ In Development
 
 **Breaking Changes:**
 
-- The parameters in :meth:`wayback.WaybackClient.get_memento` have been re-organized. All parameters from earlier versions must be specified with keywords instead of positionally, and two new parameters (``datetime`` and ``mode``) have been added.
+This release focuses on :meth:`wayback.WaybackClient.get_memento` and makes major, breaking changes to its parameters and return type. They’re all improvements, though, we promise!
 
-  1. If you previously used keywords, your code will be fine and no changes are necessary:
+**get_memento() Parameters**
 
-     .. code-block:: python
+The parameters in :meth:`wayback.WaybackClient.get_memento` have been re-organized. The method signature is now:
 
-        client.get_memento('http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/',
-                           exact=False,
-                           exact_redirects=False,
-                           target_window=3600)
+.. code-block:: python
 
-     However, positional parameters like the following will now cause problems, and you should switch to the above keyword form:
+   def get_memento(self,
+                   url,                        # Accepts new types of values.
+                   datetime=None,              # New parameter.
+                   mode=Mode.original,         # New parameter.
+                   *,                          # Everything below is keyword-only.
+                   exact=True,
+                   exact_redirects=None,
+                   target_window=24 * 60 * 60,
+                   follow_redirects=True)      # New parameter.
 
-     .. code-block:: python
+- All parameters except ``url`` (the first parameter) from v0.2.x must now be specified with keywords, and cannot be specified positionally.
 
-        # This no longer works.
-        client.get_memento('http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/',
-                           False,
-                           False,
-                           3600)
-
-  2. The ``url`` parameter can now be a non-Wayback URL or a :class:`wayback.CdxRecord`, and new ``datetime`` and ``mode`` parameters have been added.
-
-     Previously, if you wanted to get a memento of what ``http://www.noaa.gov/`` looked like on August 1, 2018, you would have had to construct a complex string to pass to ``get_memento()``:
-
-     .. code-block:: python
-
-        client.get_memento('http://web.archive.org/web/20180801000000id_/http://www.noaa.gov/')
-
-     Now you can pass the URL and time you want as separate parameters:
-
-     .. code-block:: python
-
-        client.get_memento('http://www.noaa.gov/', datetime.datetime(2018, 8, 1))
-
-        # The time can also be passed as the `datetime` keyword:
-        client.get_memento('http://www.noaa.gov/', datetime=datetime.datetime(2018, 8, 1))
-
-     If the ``datetime`` parameter does not specify a timezone, it will be treated as UTC (*not* local time).
-
-     You can also pass a :class:`wayback.CdxRecord` that you received from :meth:`wayback.WaybackClient.search` instead of a URL and time:
-
-     .. code-block:: python
-
-        for record in client.search('http://www.noaa.gov/'):
-            client.get_memento(record)
-
-     Finally, you can now specify the *playback mode* of a memento using the ``mode`` parameter:
-
-     .. code-block:: python
-
-        client.get_memento('http://www.noaa.gov/',
-                           datetime=datetime.datetime(2018, 8, 1),
-                           mode=wayback.Mode.view)
-
-     The default mode is :attr:`wayback.Mode.original`, which returns the exact HTTP response body as was originally archived. Other modes reformat the response body so it’s more friendly for browsing by changing the URLs or links, images, etc. and by adding informational content to the page (or other file type) about the memento you are viewing. They are the modes typically used when you view the Wayback Machine in a web browser.
-
-     Don’t worry, though — complete Wayback URLs are still supported. This code still works fine:
-
-     .. code-block:: python
-
-        client.get_memento('http://web.archive.org/web/20180801000000id_/http://www.noaa.gov/')
-
-- :func:`wayback.memento_url_data` now returns 3 values instead of 2. The last value is a string representing the playback mode (see above description of the new ``mode`` parameter on :meth:`wayback.WaybackClient.get_memento` for more about playback modes).
-
-- :meth:`wayback.WaybackClient.get_memento` now returns a :class:`wayback.Memento` instance instead of a ``requests.Response`` object. It has a similar interface, but provides more useful information about the Memento than just the HTTP response from Wayback. For example, ``memento.url`` is the original URL the memento is a capture of (e.g. ``http://www.noaa.gov/``) rather than the Wayback URL (e.g. ``http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/``). You can still get the full Wayback URL from ``memento.memento_url``.
-
-  You can check out the full API docs for :class:`wayback.Memento`, but here’s a quick guide to what’s available:
+  If you previously used keywords, your code will be fine and no changes are necessary:
 
   .. code-block:: python
 
-     memento = client.get_memento('http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/home',
-                                  exact=False)
+     # This still works great!
+     client.get_memento('http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/',
+                        exact=False,
+                        exact_redirects=False,
+                        target_window=3600)
 
-     # These values were previously not available except by parsing
-     # `memento.url`. The old `memento.url` is now `memento.memento_url`.
-     memento.url == 'http://www.noaa.gov/'
-     memento.timestamp == datetime.datetime(2018, 8, 29, 8, 8, 49, tzinfo=timezone.utc)
-     memento.mode == 'id_'
+  However, positional parameters like the following will now cause problems, and you should switch to the above keyword form:
 
-     # Used to be `memento.url`:
-     memento.memento_url == 'http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/'
+  .. code-block:: python
 
-     # Used to be a list of `Response` objects, now a *tuple* of Mementos. It
-     # Still lists only the redirects that are actual Mementos and not part of
-     # Wayback's internal machinery:
-     memento.history == (Memento<url='http://noaa.gov/home'>,)
+     # This will now cause you some trouble :(
+     client.get_memento('http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/',
+                        False,
+                        False,
+                        3600)
 
-     # Used to be a list of `Response` objects, now a *tuple* URL strings:
-     memento.debug_history == ('http://web.archive.org/web/20180816111911id_/http://noaa.gov/home',
-                               'http://web.archive.org/web/20180829092926id_/http://noaa.gov/home',
-                               'http://web.archive.org/web/20180829092926id_/http://noaa.gov/')
+- The ``url`` parameter can now be a normal, non-Wayback URL or a :class:`wayback.CdxRecord`, and new ``datetime`` and ``mode`` parameters have been added.
 
-     # Headers now only lists headers from the original, archived response, not
-     # additional headers from the Wayback Machine itself. (If there's
-     # important information you needed in the headers, file an issue and let
-     # us know! We'd like to surface that kind of information as attributes on
-     # the Memento now.
-     memento.headers = {'header_name': 'header_value',
-                        'another_header': 'another_value',
-                        'and': 'so on'}
+  Previously, if you wanted to get a memento of what ``http://www.noaa.gov/`` looked like on August 1, 2018, you would have had to construct a complex string to pass to ``get_memento()``:
 
-     # Same as before:
-     memento.status_code
-     memento.ok
-     memento.is_redirect
-     memento.encoding
-     memento.content
-     memento.text
+  .. code-block:: python
 
-**New Features:**
+     client.get_memento('http://web.archive.org/web/20180801000000id_/http://www.noaa.gov/')
 
-- :meth:`wayback.WaybackClient.get_memento` now takes a ``follow_redirects`` parameter. If false, *historical* redirects (i.e. redirects that happened when the requested memento was captured) are not followed. It defaults to ``True``, which is matches the old behavior of this method.
+  Now you can pass the URL and time you want as separate parameters:
+
+  .. code-block:: python
+
+     client.get_memento('http://www.noaa.gov/', datetime.datetime(2018, 8, 1))
+
+  If the ``datetime`` parameter does not specify a timezone, it will be treated as UTC (*not* local time).
+
+  You can also pass a :class:`wayback.CdxRecord` that you received from :meth:`wayback.WaybackClient.search` instead of a URL and time:
+
+  .. code-block:: python
+
+     for record in client.search('http://www.noaa.gov/'):
+         client.get_memento(record)
+
+  Finally, you can now specify the *playback mode* of a memento using the ``mode`` parameter:
+
+  .. code-block:: python
+
+     client.get_memento('http://www.noaa.gov/',
+                        datetime=datetime.datetime(2018, 8, 1),
+                        mode=wayback.Mode.view)
+
+  The default mode is :attr:`wayback.Mode.original`, which returns the exact HTTP response body as was originally archived. Other modes reformat the response body so it’s more friendly for browsing by changing the URLs of links, images, etc. and by adding informational content to the page about the memento you are viewing. They are the modes typically used when you view the Wayback Machine in a web browser.
+
+  Don’t worry, though — complete Wayback URLs are still supported. This code still works fine:
+
+  .. code-block:: python
+
+     client.get_memento('http://web.archive.org/web/20180801000000id_/http://www.noaa.gov/')
+
+- A new ``follow_redirects`` parameter specifies whether to follow *historical* redirects (i.e. redirects that happened when the requested memento was captured). It defaults to ``True``, which matches the old behavior of this method.
+
+
+**get_memento() Returns a Memento Object**
+
+``get_memento()`` no longer returns a response object from the `Requests package <https://requests.readthedocs.io/>`_. Instead it returns a specialized :class:`wayback.Memento` object, which is similar, but provides more useful information about the Memento than just the HTTP response from Wayback. For example, ``memento.url`` is the original URL the memento is a capture of (e.g. ``http://www.noaa.gov/``) rather than the Wayback URL (e.g. ``http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/``). You can still get the full Wayback URL from ``memento.memento_url``.
+
+You can check out the full API docs for :class:`wayback.Memento`, but here’s a quick guide to what’s available:
+
+.. code-block:: python
+
+   memento = client.get_memento('http://www.noaa.gov/home',
+                                datetime(2018, 8, 16, 11, 19, 11),
+                                exact=False)
+
+   # These values were previously not available except by parsing
+   # `memento.url`. The old `memento.url` is now `memento.memento_url`.
+   memento.url == 'http://www.noaa.gov/'
+   memento.timestamp == datetime(2018, 8, 29, 8, 8, 49, tzinfo=timezone.utc)
+   memento.mode == 'id_'
+
+   # Used to be `memento.url`:
+   memento.memento_url == 'http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/'
+
+   # Used to be a list of `Response` objects, now a *tuple* of Mementos. It
+   # Still lists only the redirects that are actual Mementos and not part of
+   # Wayback's internal machinery:
+   memento.history == (Memento<url='http://noaa.gov/home'>,)
+
+   # Used to be a list of `Response` objects, now a *tuple* of URL strings:
+   memento.debug_history == ('http://web.archive.org/web/20180816111911id_/http://noaa.gov/home',
+                             'http://web.archive.org/web/20180829092926id_/http://noaa.gov/home',
+                             'http://web.archive.org/web/20180829092926id_/http://noaa.gov/')
+
+   # Headers now only lists headers from the original, archived response, not
+   # additional headers from the Wayback Machine itself. (If there's
+   # important information you needed in the headers, file an issue and let
+   # us know! We'd like to surface that kind of information as attributes on
+   # the Memento now.
+   memento.headers = {'header_name': 'header_value',
+                      'another_header': 'another_value',
+                      'and': 'so on'}
+
+   # Same as before:
+   memento.status_code
+   memento.ok
+   memento.is_redirect
+   memento.encoding
+   memento.content
+   memento.text
+
+Under the hood, *Wayback* still uses `Requests <https://requests.readthedocs.io/>`_ for HTTP requests, but we expect to change that soon to ensure this package is thread-safe.
+
+
+**Other Breaking Changes**
+
+Finally, :func:`wayback.memento_url_data` now returns 3 values instead of 2. The last value is a string representing the playback mode (see above description of the new ``mode`` parameter on :meth:`wayback.WaybackClient.get_memento` for more about playback modes).
 
 
 v0.2.5 (2020-10-19)

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -114,7 +114,9 @@ Memento API. We implement a Python client that can speak both.
 .. autoclass:: wayback.CdxRecord
 
 .. autoclass:: wayback.Memento
-   :members:
+
+    .. automethod:: close
+    .. automethod:: parse_memento_headers
 
 .. autoclass:: wayback.WaybackSession
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -113,6 +113,9 @@ Memento API. We implement a Python client that can speak both.
 
 .. autoclass:: wayback.CdxRecord
 
+.. autoclass:: wayback.Memento
+   :members:
+
 .. autoclass:: wayback.WaybackSession
 
     .. automethod:: reset

--- a/wayback/__init__.py
+++ b/wayback/__init__.py
@@ -4,6 +4,7 @@ del get_versions
 
 from ._client import (  # noqa
     CdxRecord,
+    Memento,
     memento_url_data,
     Mode,
     WaybackClient,

--- a/wayback/__init__.py
+++ b/wayback/__init__.py
@@ -2,10 +2,13 @@ from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
-from ._client import (  # noqa
+from ._utils import memento_url_data  # noqa
+
+from ._models import (  # noqa
     CdxRecord,
-    Memento,
-    memento_url_data,
+    Memento)
+
+from ._client import (  # noqa
     Mode,
     WaybackClient,
     WaybackSession)

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -1044,20 +1044,46 @@ class Memento:
 
     @property
     def ok(self):
+        """
+        Whether the response had an non-error status (i.e. < 400).
+
+        Returns
+        -------
+        boolean
+        """
         return self.status_code < 400
 
     @property
     def is_redirect(self):
+        """
+        Whether the response was a redirect (i.e. had a 3xx status).
+
+        Returns
+        -------
+        boolean
+        """
         return self.ok and self.status_code < 400
 
     @property
     def content(self):
-        """The body of the archived HTTP response in bytes."""
+        """
+        The body of the archived HTTP response in bytes.
+
+        Returns
+        -------
+        bytes
+        """
         return self._raw.content
 
     @property
     def text(self):
-        """The body of the archived HTTP response decoded as a string."""
+        """
+        The body of the archived HTTP response decoded as a string.
+
+        Returns
+        -------
+        str
+        """
         return self._raw.text
 
     def close(self):
@@ -1076,7 +1102,7 @@ class Memento:
         self.close()
 
     @classmethod
-    def parse_memento_headers(self, raw_headers):
+    def parse_memento_headers(cls, raw_headers):
         """
         Extract historical headers from the Memento's HTTP response.
 

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -957,6 +957,10 @@ class WaybackClient(_utils.DepthCountedContext):
             return memento
 
 
+# NOTE: We use `py:attribute::` listings instead of the standard Numpy
+# "Attributes" section (which is formatted like function parameters) because it
+# doesn't do a great job of handling properties. See this issue:
+# https://github.com/numpy/numpydoc/issues/299
 class Memento:
     """
     Represents a memento (an archived HTTP response). This object is similar to
@@ -976,41 +980,81 @@ class Memento:
         >>>     do_something()
         >>> # Connection is automatically closed here.
 
-    Attributes
-    ----------
-    encoding : str
+    **Fields**
+
+    .. py:attribute:: encoding
+        :type: str
+
         The text encoding of the response, e.g. ``'utf-8'``.
-    headers : dict
+
+    .. py:attribute:: headers
+        :type: dict
+
         A dict representing the headers of the archived HTTP response. The keys
         are case-sensitive.
-    history : tuple of Memento
+
+    .. py:attribute:: history
+        :type: tuple[wayback.Memento]
+
         A list of :class:`wayback.Memento` objects that were redirects and were
         followed to produce this memento.
-    debug_history : tuple of str
+
+    .. py:attribute:: debug_history
+        :type: tuple[str]
+
         List of all URLs redirects followed in order to produce this memento.
         These are "memento URLs" -- that is, they are absolute URLs to the
         Wayback machine like
         ``http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/``,
         rather than URLs of captured redirects, like ``http://www.noaa.gov``.
         Many of the URLs in this list do not represent actual mementos.
-    status_code : int
+
+    .. py:attribute:: status_code
+        :type: int
+
         The HTTP status code of the archived HTTP response.
-    mode : str
+
+    .. py:attribute:: mode
+        :type: str
+
         The playback mode used to produce the Memento.
-    timestamp : datetime
+
+    .. py:attribute:: timestamp
+        :type: datetime.datetime
+
         The time the memento was originally captured. This includes ``tzinfo``,
         and will always be in UTC.
-    url : str
+
+    .. py:attribute:: url
+        :type: str
+
         The URL that the memento represents, e.g. ``http://www.noaa.gov``.
-    memento_url : str
+
+    .. py:attribute:: memento_url
+        :type: str
+
         The URL at which the memento was fetched from the Wayback Machine, e.g.
         ``http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/``.
-    media : str
-        The media type of the response.
-    ok
-    is_redirect
-    content
-    text
+
+    .. py:attribute:: ok
+        :type: bool
+
+        Whether the response had an non-error status (i.e. < 400).
+
+    .. py:attribute:: is_redirect
+        :type: bool
+
+        Whether the response was a redirect (i.e. had a 3xx status).
+
+    .. py:attribute:: content
+        :type: bytes
+
+        The body of the archived HTTP response in bytes.
+
+    .. py:attribute:: text
+        :type: str
+
+        The body of the archived HTTP response decoded as a string.
     """
     encoding = None
     headers = None

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -872,7 +872,6 @@ class WaybackClient(_utils.DepthCountedContext):
                                       timestamp=current_date,
                                       url=current_url,
                                       memento_url=response.url,
-                                      media=Memento.parse_memento_media(response),
                                       raw=response,
                                       raw_headers=response.headers)
                     if not follow_redirects:
@@ -1024,14 +1023,13 @@ class Memento:
     timestamp = None
     url = ''
     memento_url = ''
-    media = None
     _raw = None
     _raw_headers = None
 
     # TODO: determine whether this should take fewer arguments and derive some
     # of these values.
     def __init__(self, encoding, headers, history, debug_history, status_code,
-                 mode, timestamp, url, memento_url, media, raw, raw_headers):
+                 mode, timestamp, url, memento_url, raw, raw_headers):
         self.encoding = encoding
         self.headers = headers
         self.history = history
@@ -1041,7 +1039,6 @@ class Memento:
         self.timestamp = timestamp
         self.url = url
         self.memento_url = memento_url
-        self.media = media
         self._raw = raw
         self._raw_headers = raw_headers
 
@@ -1108,27 +1105,3 @@ class Memento:
             headers['Location'], _, _ = memento_url_data(raw_headers['Location'])
 
         return headers
-
-    @classmethod
-    def parse_memento_media(self, raw_response):
-        """
-        Determine the media type of the memento from its HTTP response.
-
-        Returns
-        -------
-        str
-            The main media type, e.g. ``'text/html'``.
-        dict
-            The media type's parameters, e.g. ``{'charset': 'utf-8'}`` for the
-            parsed string ``'text/html; charset=utf-8'``.
-        """
-        media, *parameters = raw_response.headers.get('content-type', '').split(';')
-
-        clean_parameters = {}
-        for parameter in parameters:
-            name, value = parameter.split('=', 1)
-            name = name.strip().lower()
-            value = value.strip()
-            clean_parameters[name] = value
-
-        return media, clean_parameters

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -1062,7 +1062,7 @@ class Memento:
         -------
         boolean
         """
-        return self.ok and self.status_code < 400
+        return self.ok and self.status_code >= 300
 
     @property
     def content(self):

--- a/wayback/_models.py
+++ b/wayback/_models.py
@@ -265,7 +265,9 @@ class Memento:
 
         # Headers that are also needed for a browser to handle the played-back
         # memento are *not* prefixed, so we need to copy over each of those.
-        for unprefixed in ('Content-Type', 'Content-Encoding'):
+        # NOTE: Historical 'Content-Encoding' headers cannot be determined from
+        # the Wayback Machine; we shouldn't pick up `Content-Encoding` here.
+        for unprefixed in ('Content-Type',):
             if unprefixed in raw_headers:
                 headers[unprefixed] = raw_headers[unprefixed]
 

--- a/wayback/_models.py
+++ b/wayback/_models.py
@@ -31,7 +31,7 @@ These attributes contain information provided directly by CDX.
 .. py:attribute:: length
 
    Size of captured content in bytes, such as :data:`2767`. This may be
-   innacurate. If the record is a "revisit record", indicated by MIME type
+   inaccurate. If the record is a "revisit record", indicated by MIME type
    :data:`'warc/revisit'`, the length seems to be the length of the reference,
    not the length of the content itself.
 

--- a/wayback/_models.py
+++ b/wayback/_models.py
@@ -78,9 +78,11 @@ And these attributes are synthesized from the information provided by CDX.
 class Memento:
     """
     Represents a memento (an archived HTTP response). This object is similar to
-    an response object from the popular "Requests" package, although it has
-    some differences designed to help differentiate and manage historical
-    information vs. current metadata about the stored memento.
+    a response object from the popular "Requests" package, although it has some
+    differences designed to differentiate historical information vs. current
+    metadata about the stored memento (for example, the ``headers`` attribute
+    lists the headers recorded in the memento, and does not include additional
+    headers that provide metadata about the Wayback Machine).
 
     Note that, like an HTTP response, this object represents a potentially open
     network connection to the Wayback Machine. Reading the ``content`` or
@@ -249,7 +251,12 @@ class Memento:
     @classmethod
     def parse_memento_headers(cls, raw_headers):
         """
-        Extract historical headers from the Memento's HTTP response.
+        Extract historical headers from the Memento HTTP response's headers.
+
+        Parameters
+        ----------
+        raw_headers : dict
+            A dict of HTTP headers from the Memento's HTTP response.
 
         Returns
         -------

--- a/wayback/_models.py
+++ b/wayback/_models.py
@@ -1,0 +1,278 @@
+from collections import namedtuple
+from ._utils import memento_url_data
+
+
+CdxRecord = namedtuple('CdxRecord', (
+    # Raw CDX values
+    'key',
+    'timestamp',
+    'url',
+    'mime_type',
+    'status_code',
+    'digest',
+    'length',
+    # Synthesized values
+    'raw_url',
+    'view_url'
+))
+"""
+Item from iterable of results returned by :meth:`WaybackClient.search`
+
+These attributes contain information provided directly by CDX.
+
+.. py:attribute:: digest
+
+   Content hashed as a base 32 encoded SHA-1.
+
+.. py:attribute:: key
+
+   SURT-formatted URL
+
+.. py:attribute:: length
+
+   Size of captured content in bytes, such as :data:`2767`. This may be
+   innacurate. If the record is a "revisit record", indicated by MIME type
+   :data:`'warc/revisit'`, the length seems to be the length of the reference,
+   not the length of the content itself.
+
+.. py:attribute:: mime_type
+
+   MIME type of record, such as :data:`'text/html'`, :data:`'warc/revisit'` or
+   :data:`'unk'` ("unknown") if this information was not captured.
+
+.. py:attribute:: status_code
+
+   Status code returned by the server when the record was captured, such as
+   :data:`200`. This is may be :data:`None` if the record is a revisit record.
+
+.. py:attribute:: timestamp
+
+   The capture time represented as a :class:`datetime.datetime`, such as
+   :data:`datetime.datetime(1996, 12, 31, 23, 58, 47, tzinfo=timezone.utc)`.
+
+.. py:attribute:: url
+
+   The URL that was captured by this record, such as
+   :data:`'http://www.nasa.gov/'`.
+
+And these attributes are synthesized from the information provided by CDX.
+
+.. py:attribute:: raw_url
+
+   The URL to the raw captured content, such as
+   :data:`'http://web.archive.org/web/19961231235847id_/http://www.nasa.gov/'`.
+
+.. py:attribute:: view_url
+
+   The URL to the public view on Wayback Machine. In this view, the links and
+   some subresources in the document are rewritten to point to Wayback URLs.
+   There is also a navigation panel around the content. Example URL:
+   :data:`'http://web.archive.org/web/19961231235847/http://www.nasa.gov/'`.
+"""
+
+
+# NOTE: We use `py:attribute::` listings instead of the standard Numpy
+# "Attributes" section (which is formatted like function parameters) because it
+# doesn't do a great job of handling properties. See this issue:
+# https://github.com/numpy/numpydoc/issues/299
+class Memento:
+    """
+    Represents a memento (an archived HTTP response). This object is similar to
+    an response object from the popular "Requests" package, although it has
+    some differences designed to help differentiate and manage historical
+    information vs. current metadata about the stored memento.
+
+    Note that, like an HTTP response, this object represents a potentially open
+    network connection to the Wayback Machine. Reading the ``content`` or
+    ``text`` attributes will read all the data being received and close the
+    connection automatically, but if you do not read those properties, you must
+    make sure to call ``close()`` to close to connection. Alternatively, you
+    can use a Memento as a context manager. The connection will be closed for
+    you when the context ends:
+
+        >>> with a_memento:
+        >>>     do_something()
+        >>> # Connection is automatically closed here.
+
+    **Fields**
+
+    .. py:attribute:: encoding
+        :type: str
+
+        The text encoding of the response, e.g. ``'utf-8'``.
+
+    .. py:attribute:: headers
+        :type: dict
+
+        A dict representing the headers of the archived HTTP response. The keys
+        are case-sensitive.
+
+    .. py:attribute:: history
+        :type: tuple[wayback.Memento]
+
+        A list of :class:`wayback.Memento` objects that were redirects and were
+        followed to produce this memento.
+
+    .. py:attribute:: debug_history
+        :type: tuple[str]
+
+        List of all URLs redirects followed in order to produce this memento.
+        These are "memento URLs" -- that is, they are absolute URLs to the
+        Wayback machine like
+        ``http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/``,
+        rather than URLs of captured redirects, like ``http://www.noaa.gov``.
+        Many of the URLs in this list do not represent actual mementos.
+
+    .. py:attribute:: status_code
+        :type: int
+
+        The HTTP status code of the archived HTTP response.
+
+    .. py:attribute:: mode
+        :type: str
+
+        The playback mode used to produce the Memento.
+
+    .. py:attribute:: timestamp
+        :type: datetime.datetime
+
+        The time the memento was originally captured. This includes ``tzinfo``,
+        and will always be in UTC.
+
+    .. py:attribute:: url
+        :type: str
+
+        The URL that the memento represents, e.g. ``http://www.noaa.gov``.
+
+    .. py:attribute:: memento_url
+        :type: str
+
+        The URL at which the memento was fetched from the Wayback Machine, e.g.
+        ``http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/``.
+
+    .. py:attribute:: ok
+        :type: bool
+
+        Whether the response had an non-error status (i.e. < 400).
+
+    .. py:attribute:: is_redirect
+        :type: bool
+
+        Whether the response was a redirect (i.e. had a 3xx status).
+
+    .. py:attribute:: content
+        :type: bytes
+
+        The body of the archived HTTP response in bytes.
+
+    .. py:attribute:: text
+        :type: str
+
+        The body of the archived HTTP response decoded as a string.
+    """
+
+    def __init__(self, *, url, timestamp, mode, memento_url, status_code,
+                 headers, encoding, raw, raw_headers, history, debug_history):
+        self.url = url
+        self.timestamp = timestamp
+        self.mode = mode
+        self.memento_url = memento_url
+        self.status_code = status_code
+        self.headers = headers
+        self.encoding = encoding
+        self._raw = raw
+        self._raw_headers = raw_headers
+
+        # Ensure we have non-mutable copies of history info.
+        self.history = tuple(history)
+        self.debug_history = tuple(debug_history)
+
+    @property
+    def ok(self):
+        """
+        Whether the response had an non-error status (i.e. < 400).
+
+        Returns
+        -------
+        boolean
+        """
+        return self.status_code < 400
+
+    @property
+    def is_redirect(self):
+        """
+        Whether the response was a redirect (i.e. had a 3xx status).
+
+        Returns
+        -------
+        boolean
+        """
+        return self.ok and self.status_code >= 300
+
+    @property
+    def content(self):
+        """
+        The body of the archived HTTP response in bytes.
+
+        Returns
+        -------
+        bytes
+        """
+        return self._raw.content
+
+    @property
+    def text(self):
+        """
+        The body of the archived HTTP response decoded as a string.
+
+        Returns
+        -------
+        str
+        """
+        return self._raw.text
+
+    def close(self):
+        """
+        Close the HTTP response for this Memento. This happens automatically if
+        you read ``content`` or ``text``, and if you use the memento as a
+        context manager. This method is always safe to call -- it does nothing
+        if the response has already been closed.
+        """
+        self._raw.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
+
+    @classmethod
+    def parse_memento_headers(cls, raw_headers):
+        """
+        Extract historical headers from the Memento's HTTP response.
+
+        Returns
+        -------
+        dict
+        """
+        # Archived, historical headers are all reproduced as headers in the
+        # memento response, but start with "X-Archive-Orig-".
+        prefix = 'X-Archive-Orig-'
+        headers = {
+            key[len(prefix):]: value for key, value in raw_headers.items()
+            if key.startswith(prefix)
+        }
+
+        # Headers that are also needed for a browser to handle the played-back
+        # memento are *not* prefixed, so we need to copy over each of those.
+        for unprefixed in ('Content-Type', 'Content-Encoding'):
+            if unprefixed in raw_headers:
+                headers[unprefixed] = raw_headers[unprefixed]
+
+        # The `Location` header for a redirect does not have an X-Archive-Orig-
+        # version, and the normal location header point to the next *Wayback*
+        # URL, so we need to parse it to get the historical redirect URL.
+        if 'Location' in raw_headers:
+            headers['Location'], _, _ = memento_url_data(raw_headers['Location'])
+
+        return headers

--- a/wayback/_utils.py
+++ b/wayback/_utils.py
@@ -78,16 +78,11 @@ def ensure_utc_datetime(value):
         raise TypeError('`datetime` must be a string, date, or datetime')
 
 
-def split_memento_url(memento_url):
-    'Extract the raw date and URL components from a memento URL.'
-    match = MEMENTO_URL_PATTERN.match(memento_url)
-    if match is None:
-        raise ValueError(f'"{memento_url}" is not a memento URL')
-
-    return match.group(3), match.group(1), match.group(2) or ''
-
-
 def clean_memento_url_component(url):
+    """
+    Attempt to fix encoding or other issues with the target URL that was
+    embedded in a memento URL.
+    """
     # A URL *may* be percent encoded, decode ONLY if so (we don’t want to
     # accidentally decode the querystring if there is one)
     lower_url = url.lower()
@@ -104,7 +99,7 @@ def memento_url_data(memento_url):
 
     Returns
     -------
-    url : str, datetime.datetime, str
+    url : str
         The URL that the memento is a capture of.
     time : datetime.datetime
         The time the memento was captured in the UTC timezone.
@@ -122,9 +117,13 @@ def memento_url_data(memento_url):
      datetime.datetime(2017, 8, 13, 19, 50, 36, tzinfo=timezone.utc),
      'id_')
     """
-    raw_url, timestamp, mode = split_memento_url(memento_url)
-    url = clean_memento_url_component(raw_url)
-    date = parse_timestamp(timestamp)
+    match = MEMENTO_URL_PATTERN.match(memento_url)
+    if match is None:
+        raise ValueError(f'"{memento_url}" is not a memento URL')
+
+    url = clean_memento_url_component(match.group(3))
+    date = parse_timestamp(match.group(1))
+    mode = match.group(2) or ''
 
     return url, date, mode
 

--- a/wayback/_utils.py
+++ b/wayback/_utils.py
@@ -1,10 +1,132 @@
 from collections import defaultdict
 from contextlib import contextmanager
+from datetime import date, datetime, timezone
+import re
 import requests
 import requests.adapters
 import threading
 import time
+import urllib.parse
 from .exceptions import SessionClosedError
+
+
+URL_DATE_FORMAT = '%Y%m%d%H%M%S'
+MEMENTO_URL_PATTERN = re.compile(
+    r'^http(?:s)?://web.archive.org/web/(\d+)(\w\w_)?/(.+)$')
+
+
+def format_timestamp(value):
+    """
+    Format a value as a Wayback-style timestamp string.
+
+    Parameters
+    ----------
+    value : str or datetime.datetime or datetime.date
+
+    Returns
+    -------
+    str
+    """
+    if isinstance(value, str):
+        return value
+    elif isinstance(value, datetime):
+        # Make sure we have either a naive datetime (assumed to
+        # represent UTC) or convert the datetime to UTC.
+        if value.tzinfo:
+            value_utc = value.astimezone(timezone.utc)
+        else:
+            value_utc = value
+        return value_utc.strftime(URL_DATE_FORMAT)
+    elif isinstance(value, date):
+        return value.strftime(URL_DATE_FORMAT)
+    else:
+        raise TypeError('Timestamp must be a datetime, date, or string')
+
+
+def parse_timestamp(time_string):
+    """
+    Given a Wayback-style timestamp string, return an equivalent ``datetime``.
+    """
+    return (datetime
+            .strptime(time_string, URL_DATE_FORMAT)
+            .replace(tzinfo=timezone.utc))
+
+
+def ensure_utc_datetime(value):
+    """
+    Given a datetime, date, or Wayback-style timestamp string, return an
+    equivalent datetime in UTC.
+
+    Parameters
+    ----------
+    value : str or datetime.datetime or datetime.date
+
+    Returns
+    -------
+    datetime.datetime
+    """
+    if isinstance(value, str):
+        return parse_timestamp(value)
+    elif isinstance(value, datetime):
+        if value.tzinfo:
+            return value.astimezone(timezone.utc)
+        else:
+            return value.replace(tzinfo=timezone.utc)
+    elif isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
+    else:
+        raise TypeError('`datetime` must be a string, date, or datetime')
+
+
+def split_memento_url(memento_url):
+    'Extract the raw date and URL components from a memento URL.'
+    match = MEMENTO_URL_PATTERN.match(memento_url)
+    if match is None:
+        raise ValueError(f'"{memento_url}" is not a memento URL')
+
+    return match.group(3), match.group(1), match.group(2) or ''
+
+
+def clean_memento_url_component(url):
+    # A URL *may* be percent encoded, decode ONLY if so (we don’t want to
+    # accidentally decode the querystring if there is one)
+    lower_url = url.lower()
+    if lower_url.startswith('http%3a') or lower_url.startswith('https%3a'):
+        url = urllib.parse.unquote(url)
+
+    return url
+
+
+def memento_url_data(memento_url):
+    """
+    Get the original URL, time, and mode that a memento URL represents a
+    capture of.
+
+    Returns
+    -------
+    url : str, datetime.datetime, str
+        The URL that the memento is a capture of.
+    time : datetime.datetime
+        The time the memento was captured in the UTC timezone.
+    mode : str
+        The playback mode.
+
+    Examples
+    --------
+    Extract original URL, time and mode.
+
+    >>> url = ('http://web.archive.org/web/20170813195036id_/'
+    ...        'https://arpa-e.energy.gov/?q=engage/events-workshops')
+    >>> memento_url_data(url)
+    ('https://arpa-e.energy.gov/?q=engage/events-workshops',
+     datetime.datetime(2017, 8, 13, 19, 50, 36, tzinfo=timezone.utc),
+     'id_')
+    """
+    raw_url, timestamp, mode = split_memento_url(memento_url)
+    url = clean_memento_url_component(raw_url)
+    date = parse_timestamp(timestamp)
+
+    return url, date, mode
 
 
 _last_call_by_group = defaultdict(int)

--- a/wayback/tests/test_client.py
+++ b/wayback/tests/test_client.py
@@ -274,8 +274,7 @@ def test_get_memento_with_archive_url():
         assert 200 == memento.status_code
         assert memento.ok
         assert not memento.is_redirect
-        assert {'Content-Encoding': 'gzip',
-                'Content-Type': 'text/html',
+        assert {'Content-Type': 'text/html',
                 'Date': 'Fri, 24 Nov 2017 15:13:14 GMT',
                 'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
                 'Transfer-Encoding': 'chunked'} == memento.headers

--- a/wayback/tests/test_client.py
+++ b/wayback/tests/test_client.py
@@ -6,8 +6,7 @@ from .._utils import SessionClosedError
 from .._client import (CdxRecord,
                        Mode,
                        WaybackSession,
-                       WaybackClient,
-                       memento_url_data)
+                       WaybackClient)
 from ..exceptions import MementoPlaybackError, RateLimitError, BlockedSiteError
 
 
@@ -184,43 +183,6 @@ def test_search_removes_malformed_entries(requests_mock):
                                 to_date=datetime(2020, 4, 19))
 
         assert 2 == len(list(records))
-
-
-class TestMementoUrlData:
-    def test_extracts_url(self):
-        url, timestamp, mode = memento_url_data(
-            'http://web.archive.org/web/20170813195036/'
-            'https://arpa-e.energy.gov/?q=engage/events-workshops')
-        assert url == 'https://arpa-e.energy.gov/?q=engage/events-workshops'
-        assert timestamp == datetime(2017, 8, 13, 19, 50, 36, tzinfo=timezone.utc)
-        assert mode == ''
-
-        url, timestamp, mode = memento_url_data(
-            'http://web.archive.org/web/20170813195036id_/'
-            'https://arpa-e.energy.gov/?q=engage/events-workshops')
-        assert url == 'https://arpa-e.energy.gov/?q=engage/events-workshops'
-        assert timestamp == datetime(2017, 8, 13, 19, 50, 36, tzinfo=timezone.utc)
-        assert mode == 'id_'
-
-    def test_decodes_url(self):
-        url, _, _ = memento_url_data(
-            'http://web.archive.org/web/20150930233055id_/'
-            'http%3A%2F%2Fwww.epa.gov%2Fenvironmentaljustice%2Fgrants%2Fej-smgrants.html%3Futm')
-        assert url == 'http://www.epa.gov/environmentaljustice/grants/ej-smgrants.html?utm'
-
-    def test_does_not_decode_query(self):
-        url, _, _ = memento_url_data(
-            'http://web.archive.org/web/20170813195036/'
-            'https://arpa-e.energy.gov/?q=engage%2Fevents-workshops')
-        assert url == 'https://arpa-e.energy.gov/?q=engage%2Fevents-workshops'
-
-    def test_raises_for_non_memento_urls(self):
-        with pytest.raises(ValueError):
-            memento_url_data('http://whatever.com')
-
-    def test_raises_for_non_string_input(self):
-        with pytest.raises(TypeError):
-            memento_url_data(None)
 
 
 @ia_vcr.use_cassette()

--- a/wayback/tests/test_client.py
+++ b/wayback/tests/test_client.py
@@ -7,7 +7,6 @@ from .._client import (CdxRecord,
                        Mode,
                        WaybackSession,
                        WaybackClient,
-                       original_url_for_memento,
                        memento_url_data)
 from ..exceptions import MementoPlaybackError, RateLimitError, BlockedSiteError
 
@@ -180,94 +179,97 @@ def test_search_removes_malformed_entries(requests_mock):
         assert 2 == len(list(records))
 
 
-class TestOriginalUrlForMemento:
+class TestMementoUrlData:
     def test_extracts_url(self):
-        url = original_url_for_memento(
+        url, timestamp, mode = memento_url_data(
             'http://web.archive.org/web/20170813195036/'
             'https://arpa-e.energy.gov/?q=engage/events-workshops')
         assert url == 'https://arpa-e.energy.gov/?q=engage/events-workshops'
+        assert timestamp == datetime(2017, 8, 13, 19, 50, 36, tzinfo=timezone.utc)
+        assert mode == ''
 
-        url = original_url_for_memento(
+        url, timestamp, mode = memento_url_data(
             'http://web.archive.org/web/20170813195036id_/'
             'https://arpa-e.energy.gov/?q=engage/events-workshops')
         assert url == 'https://arpa-e.energy.gov/?q=engage/events-workshops'
+        assert timestamp == datetime(2017, 8, 13, 19, 50, 36, tzinfo=timezone.utc)
+        assert mode == 'id_'
 
     def test_decodes_url(self):
-        url = original_url_for_memento(
+        url, _, _ = memento_url_data(
             'http://web.archive.org/web/20150930233055id_/'
             'http%3A%2F%2Fwww.epa.gov%2Fenvironmentaljustice%2Fgrants%2Fej-smgrants.html%3Futm')
         assert url == 'http://www.epa.gov/environmentaljustice/grants/ej-smgrants.html?utm'
 
     def test_does_not_decode_query(self):
-        url = original_url_for_memento(
+        url, _, _ = memento_url_data(
             'http://web.archive.org/web/20170813195036/'
             'https://arpa-e.energy.gov/?q=engage%2Fevents-workshops')
         assert url == 'https://arpa-e.energy.gov/?q=engage%2Fevents-workshops'
 
     def test_raises_for_non_memento_urls(self):
         with pytest.raises(ValueError):
-            original_url_for_memento('http://whatever.com')
+            memento_url_data('http://whatever.com')
 
     def test_raises_for_non_string_input(self):
         with pytest.raises(TypeError):
-            original_url_for_memento(None)
+            memento_url_data(None)
 
 
 @ia_vcr.use_cassette()
 def test_get_memento():
     with WaybackClient() as client:
-        response = client.get_memento('https://www.fws.gov/birds/',
-                                      datetime=datetime(2017, 11, 24, 15, 13, 15))
-        assert 'Link' in response.headers
-        original, *_ = response.headers['Link'].split(',', 1)
-        assert original == '<https://www.fws.gov/birds/>; rel="original"'
+        memento = client.get_memento('https://www.fws.gov/birds/',
+                                     datetime=datetime(2017, 11, 24, 15, 13, 15))
+        assert 'https://www.fws.gov/birds/' == memento.url
+        assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
+        assert 'id_' == memento.mode
 
 
 @ia_vcr.use_cassette()
 def test_get_memento_with_date_datetime():
     with WaybackClient() as client:
-        response = client.get_memento('https://www.fws.gov/birds/',
-                                      datetime=date(2017, 11, 24),
-                                      exact=False)
-        assert 'Link' in response.headers
-        original, *_ = response.headers['Link'].split(',', 1)
-        assert original == '<https://www.fws.gov/birds/>; rel="original"'
+        memento = client.get_memento('https://www.fws.gov/birds/',
+                                     datetime=date(2017, 11, 24),
+                                     exact=False)
+        assert 'https://www.fws.gov/birds/' == memento.url
+        assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
+        assert 'id_' == memento.mode
 
 
 @ia_vcr.use_cassette()
 def test_get_memento_with_string_datetime():
     with WaybackClient() as client:
-        response = client.get_memento('https://www.fws.gov/birds/',
-                                      datetime='20171124151315')
-        assert 'Link' in response.headers
-        original, *_ = response.headers['Link'].split(',', 1)
-        assert original == '<https://www.fws.gov/birds/>; rel="original"'
+        memento = client.get_memento('https://www.fws.gov/birds/',
+                                     datetime='20171124151315')
+        assert 'https://www.fws.gov/birds/' == memento.url
+        assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
+        assert 'id_' == memento.mode
 
 
 @ia_vcr.use_cassette()
 def test_get_memento_with_inexact_string_datetime():
     with WaybackClient() as client:
-        response = client.get_memento('https://www.fws.gov/birds/',
-                                      datetime='20171124151310',
-                                      exact=False)
-        assert 'Link' in response.headers
-        original, *_ = response.headers['Link'].split(',', 1)
-        assert original == '<https://www.fws.gov/birds/>; rel="original"'
+        memento = client.get_memento('https://www.fws.gov/birds/',
+                                     datetime='20171124151310',
+                                     exact=False)
+        assert 'https://www.fws.gov/birds/' == memento.url
+        assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
+        assert 'id_' == memento.mode
 
 
 @ia_vcr.use_cassette()
 def test_get_memento_handles_non_utc_datetime():
     with WaybackClient() as client:
-        # Note the offset between requested_time and expected_timestamp.
+        # Note the offset between requested_time and memento.timestamp.
         requested_time = datetime(2017, 11, 24, 8, 13, 15,
                                   tzinfo=timezone(timedelta(hours=-7)))
-        expected_time = '20171124151315'
-        expected_url = (f'http://web.archive.org/web/{expected_time}id_/'
-                        'https://www.fws.gov/birds/')
+        memento = client.get_memento('https://www.fws.gov/birds/',
+                                     datetime=requested_time)
 
-        response = client.get_memento('https://www.fws.gov/birds/',
-                                      datetime=requested_time)
-        assert expected_url == response.url
+        assert 'https://www.fws.gov/birds/' == memento.url
+        assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
+        assert 'id_' == memento.mode
 
 
 @ia_vcr.use_cassette()
@@ -288,11 +290,11 @@ def test_get_memento_with_requires_datetime_with_regular_url():
 @ia_vcr.use_cassette()
 def test_get_memento_with_archive_url():
     with WaybackClient() as client:
-        response = client.get_memento(
+        memento = client.get_memento(
             'http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/')
-        assert 'Link' in response.headers
-        original, *_ = response.headers['Link'].split(',', 1)
-        assert original == '<https://www.fws.gov/birds/>; rel="original"'
+        assert 'https://www.fws.gov/birds/' == memento.url
+        assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
+        assert 'id_' == memento.mode
 
 
 @ia_vcr.use_cassette()
@@ -307,32 +309,35 @@ def test_get_memento_with_cdx_record():
                            100,
                            'http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/',
                            'http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/')
-        response = client.get_memento(record)
-        assert 'Link' in response.headers
-        original, *_ = response.headers['Link'].split(',', 1)
-        assert original == '<https://www.fws.gov/birds/>; rel="original"'
+        memento = client.get_memento(record)
+        assert 'https://www.fws.gov/birds/' == memento.url
+        assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
+        assert 'id_' == memento.mode
 
 
 @ia_vcr.use_cassette()
 def test_get_memento_with_mode():
     with WaybackClient() as client:
-        response = client.get_memento('https://www.fws.gov/birds/',
-                                      datetime=datetime(2017, 11, 24, 15, 13, 15),
-                                      mode=Mode.view)
-        assert 'http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/' == response.url
+        memento = client.get_memento('https://www.fws.gov/birds/',
+                                     datetime=datetime(2017, 11, 24, 15, 13, 15),
+                                     mode=Mode.view)
+        assert '' == memento.mode
+        assert 'http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/' == memento.memento_url
 
-        response = client.get_memento('https://www.fws.gov/birds/',
-                                      datetime=datetime(2017, 11, 24, 15, 13, 15))
-        assert 'http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/' == response.url
+        memento = client.get_memento('https://www.fws.gov/birds/',
+                                     datetime=datetime(2017, 11, 24, 15, 13, 15))
+        assert 'id_' == memento.mode
+        assert 'http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/' == memento.memento_url
 
 
 @ia_vcr.use_cassette()
 def test_get_memento_with_mode_string():
     with WaybackClient() as client:
-        response = client.get_memento('https://www.fws.gov/birds/',
-                                      datetime=datetime(2017, 11, 24, 15, 13, 15),
-                                      mode='id_')
-        assert 'http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/' == response.url
+        memento = client.get_memento('https://www.fws.gov/birds/',
+                                     datetime=datetime(2017, 11, 24, 15, 13, 15),
+                                     mode='id_')
+        assert 'id_' == memento.mode
+        assert 'http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/' == memento.memento_url
 
 
 @ia_vcr.use_cassette()
@@ -347,10 +352,10 @@ def test_get_memento_with_mode_boolean_is_not_allowed():
 @ia_vcr.use_cassette()
 def test_get_memento_with_redirects():
     with WaybackClient() as client:
-        response = client.get_memento(
+        memento = client.get_memento(
             'http://web.archive.org/web/20180808094144id_/https://www.epa.gov/ghgreporting/san5779-factsheet')
-        assert len(response.history) == 1        # memento redirects
-        assert len(response.debug_history) == 2  # actual HTTP redirects
+        assert len(memento.history) == 1        # memento redirects
+        assert len(memento.debug_history) == 2  # actual HTTP redirects
 
 
 @ia_vcr.use_cassette()
@@ -358,27 +363,25 @@ def test_get_memento_raises_for_mementos_that_redirect_in_a_loop():
     with WaybackClient() as client:
         with pytest.raises(MementoPlaybackError):
             client.get_memento(
-                'http://web.archive.org/web/20200925075402id_/'
-                'https://link.springer.com/article/10.1007/s00382-012-1331-2')
+                'https://link.springer.com/article/10.1007/s00382-012-1331-2',
+                '20200925075402')
 
 
 @ia_vcr.use_cassette()
 def test_get_memento_should_fail_for_non_playbackable_mementos():
     with WaybackClient() as client:
         with pytest.raises(MementoPlaybackError):
-            client.get_memento(
-                'http://web.archive.org/web/20170929002712id_/https://www.fws.gov/birds/')
+            client.get_memento('https://www.fws.gov/birds/', '20170929002712')
 
 
 @ia_vcr.use_cassette()
 def test_get_memento_target_window():
     with WaybackClient() as client:
-        response = client.get_memento('https://www.fws.gov/birds/',
-                                      datetime(2017, 11, 1),
-                                      exact=False,
-                                      target_window=25 * 24 * 60 * 60)
-        _, memento_time, _ = memento_url_data(response.url)
-        assert memento_time == datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc)
+        memento = client.get_memento('https://www.fws.gov/birds/',
+                                     date(2017, 11, 1),
+                                     exact=False,
+                                     target_window=25 * 24 * 60 * 60)
+        assert memento.timestamp == datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc)
 
 
 @ia_vcr.use_cassette()
@@ -386,7 +389,7 @@ def test_get_memento_raises_when_memento_is_outside_target_window():
     with pytest.raises(MementoPlaybackError):
         with WaybackClient() as client:
             client.get_memento('https://www.fws.gov/birds/',
-                               datetime(2017, 11, 1),
+                               date(2017, 11, 1),
                                exact=False,
                                target_window=24 * 60 * 60)
 
@@ -395,8 +398,7 @@ def test_get_memento_raises_when_memento_is_outside_target_window():
 def test_get_memento_raises_blocked_error():
     with WaybackClient() as client:
         with pytest.raises(BlockedSiteError):
-            client.get_memento(
-                'http://web.archive.org/web/20170929002712id_/https://nationalpost.com/health/')
+            client.get_memento('https://nationalpost.com/health/', '20170929002712')
 
 
 @ia_vcr.use_cassette()
@@ -417,10 +419,11 @@ def test_get_memento_follows_historical_redirects():
                      'http://epa.gov/climatechange')
         target = ('http://web.archive.org/web/20200201024405id_/'
                   'https://www.epa.gov/sites/production/files/signpost/cc.html')
-        response = client.get_memento(start_url, exact=False)
-        assert response.url == target
-        assert len(response.history) == 1
-        assert len(response.debug_history) == 3
+        memento = client.get_memento(start_url, exact=False)
+        assert 'https://www.epa.gov/sites/production/files/signpost/cc.html' == memento.url
+        assert target == memento.memento_url
+        assert len(memento.history) == 1
+        assert len(memento.debug_history) == 3
 
 
 @ia_vcr.use_cassette()
@@ -442,10 +445,13 @@ def test_get_memento_follow_redirects_does_not_follow_historical_redirects():
                      'http://epa.gov/climatechange')
         target = ('http://web.archive.org/web/20200201023757id_/'
                   'https://www.epa.gov/climatechange')
-        response = client.get_memento(start_url, exact=False, follow_redirects=False)
-        assert response.url == target
-        assert len(response.history) == 0
-        assert len(response.debug_history) == 1
+        memento = client.get_memento(start_url, exact=False, follow_redirects=False)
+        assert 'https://www.epa.gov/climatechange' == memento.url
+        assert target == memento.memento_url
+        assert memento.status_code == 301
+        assert 'https://www.epa.gov/sites/production/files/signpost/cc.html' == memento.headers['Location']
+        assert len(memento.history) == 0
+        assert len(memento.debug_history) == 1
 
 
 class TestWaybackSession:

--- a/wayback/tests/test_client.py
+++ b/wayback/tests/test_client.py
@@ -338,6 +338,26 @@ def test_get_memento_with_mode_boolean_is_not_allowed():
 
 
 @ia_vcr.use_cassette()
+def test_get_memento_target_window():
+    with WaybackClient() as client:
+        memento = client.get_memento('https://www.fws.gov/birds/',
+                                     date(2017, 11, 1),
+                                     exact=False,
+                                     target_window=25 * 24 * 60 * 60)
+        assert memento.timestamp == datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc)
+
+
+@ia_vcr.use_cassette()
+def test_get_memento_raises_when_memento_is_outside_target_window():
+    with pytest.raises(MementoPlaybackError):
+        with WaybackClient() as client:
+            client.get_memento('https://www.fws.gov/birds/',
+                               date(2017, 11, 1),
+                               exact=False,
+                               target_window=24 * 60 * 60)
+
+
+@ia_vcr.use_cassette()
 def test_get_memento_with_redirects():
     with WaybackClient() as client:
         memento = client.get_memento(
@@ -360,26 +380,6 @@ def test_get_memento_should_fail_for_non_playbackable_mementos():
     with WaybackClient() as client:
         with pytest.raises(MementoPlaybackError):
             client.get_memento('https://www.fws.gov/birds/', '20170929002712')
-
-
-@ia_vcr.use_cassette()
-def test_get_memento_target_window():
-    with WaybackClient() as client:
-        memento = client.get_memento('https://www.fws.gov/birds/',
-                                     date(2017, 11, 1),
-                                     exact=False,
-                                     target_window=25 * 24 * 60 * 60)
-        assert memento.timestamp == datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc)
-
-
-@ia_vcr.use_cassette()
-def test_get_memento_raises_when_memento_is_outside_target_window():
-    with pytest.raises(MementoPlaybackError):
-        with WaybackClient() as client:
-            client.get_memento('https://www.fws.gov/birds/',
-                               date(2017, 11, 1),
-                               exact=False,
-                               target_window=24 * 60 * 60)
 
 
 @ia_vcr.use_cassette()

--- a/wayback/tests/test_files/fws-gov-birds.txt
+++ b/wayback/tests/test_files/fws-gov-birds.txt
@@ -1,0 +1,1599 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!-->
+<html class="no-js"><!-- InstanceBegin template="/Templates/home.dwt.php" codeOutsideHTMLIsLocked="false" -->
+<!--<![endif]-->
+<head>
+<!-- InstanceBeginEditable name="doctitle" -->
+<title>U.S. Fish &amp; Wildlife Service - Migratory Bird Program | Conserving America's Birds</title>
+<!-- InstanceEndEditable -->
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<link rel="shortcut icon" href="/birds/favicon.ico?" type="image/x-icon">
+<link rel="apple-touch-icon" href="/birds/apple-touch-icon.png" />
+
+<script src="/birdhabitat/js/vendor/modernizr-2.6.2.min.js"></script>
+<script type="text/javascript" src="//use.typekit.net/dhg2ksl.js"></script>
+<script type="text/javascript">try{Typekit.load();}catch(e){}</script>
+<!-- THIS IS THE TYPEKIT HOSTED BY BLUEWATER
+<script type="text/javascript" src="//use.typekit.net/xmt4eti.js"></script>
+<script type="text/javascript">try{Typekit.load();}catch(e){}</script> -->
+
+<link rel="stylesheet" href="/birdhabitat/css/normalize.min.css">
+<link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet" type="text/css">
+<link type="text/css" rel="stylesheet" media="all" href="/birdhabitat/css/mobile-menu/jquery.mmenu.css" />
+<link type="text/css" rel="stylesheet" media="all" href="/birdhabitat/css/mobile-menu/extensions/jquery.mmenu.positioning.css" />
+<link rel="stylesheet" href="/birdhabitat/css/main.css">
+<link rel="stylesheet" href="/birdhabitat/css/custom-styling.css">
+<!-- InstanceBeginEditable name="head" -->
+<!--edit <head> data here-->
+<meta name="google-site-verification" content="P-7u2YYPVRbLDLfQrAV737B5lDn-HIl3FU15agfYFNQ">
+<!-- InstanceEndEditable -->
+<!-- InstanceParam name="News Row 2 Optional" type="boolean" value="true" -->
+</head>
+
+<body class="home-page">
+<!--this wrapping div is used for the mobile nav-->
+<div>
+
+<header id="masthead">
+	<div id="skip"><a href="#content">Skip to Main Content</a></div>
+	<div class="wrap" id="main-logo">
+		<div class="logo"><a href="https://www.fws.gov"><img src="/birdhabitat/img/framework/logo.png" width="143" height="171" alt="U.S. Fish & Wildlife Service - Department of the Interior"/></a></div>
+	</div>
+	
+	<div class="row-1">
+		<div class="wrap">
+			<!--<h1><a href="http://www.fws.gov">U.S. Fish &amp; Wildlife Service</a></h1>-->
+      <div class="logo"><a href="https://www.fws.gov"><img src="/birdhabitat/img/framework/us-fish-and-wildlife-service.png" width="168" height="14" alt="U.S. Fish &amp; Wildlife Service"></a></div>
+			<nav>
+				<ul>
+					<li class="home"><a href="/birds/index.php"><i class="fa fa-fw fa-home"></i> <span>Home</span></a></li>
+					<li class="about"><a href="/birds/about-us.php"><i class="fa fa-fw fa-tree"></i> About Us</a></li>
+                    <li class="faqs"><a href="/birds/faqs.php"><i class="fa fa-fw fa-question"></i> <span>FAQs</span></a></li>
+					<li class="email button"><a href="mailto:migratorybirds@fws.gov"><i class="fa fa-fw fa-envelope"></i> <span>Email</span></a></li>
+                    <li class="facebook button"><a href="https://www.facebook.com/usfwsmigratorybirds" title="Link to non-FWS site"><i class="fa fa-fw fa-facebook"></i> <span>Facebook</span></a></li>
+					<li class="twitter button"><a href="https://twitter.com/usfwsbirds" title="Link to non-FWS site"><i class="fa fa-fw fa-twitter"></i> <span>Twitter</span></a></li>
+					<li class="search button"><a href="#"><i class="fa fa-fw fa-search"></i>  <span>Search</span></a>
+            <form accept-charset="UTF-8" action="https://search.usa.gov/search" id="search_form" method="get">
+              <div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div>
+              <input id="affiliate" name="affiliate" type="hidden" value="fws.gov" />
+              <label for="query">Enter Search Term(s):</label>
+              <input autocomplete="off" class="usagov-search-autocomplete" id="query" name="query" type="text" />
+              <input name="commit" type="submit" value="Search" />
+            </form>
+          </li>
+					<li class="menu button"><a href="#mobile-menu"><i class="fa fa-fw fa-bars"></i>  <span>Menu</span></a></li>
+				</ul>
+			</nav>
+		</div>
+	</div>
+	<div class="row-2">
+		<div class="wrap"><div class="logo"><a href="/birds/index.php"><img src="/birdhabitat/img/framework/migratory-bird-program.png" width="336" height="17" alt="Migratory Bird Program | Conserving America's Birds"></a></div></div>
+	</div>
+	<div id="main-nav">
+		<div class="wrap">
+			<nav class="animenu">
+<ul>
+	<li class="first"><a href="/birds/bird-enthusiasts.php">Bird Enthusiasts</a>
+    <ul>
+      <li><a href="/birds/bird-enthusiasts/bird-watching.php">Bird Watching</a>
+        <ul>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/bird-identification.php">Bird Identification</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification.php">Waterfowl Identification</a>
+          	<ul>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/american-black-duck.php">American Black Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/american-wigeon.php">Aerican Wigeon</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/barrows-goldeneye.php">Barrows Goldeneye</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/black-scoter.php">Black Scoter</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/blue-winged-teal.php">Blue-winged Teal</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/brant.php">Brant</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/bufflehead.php">Bufflehead</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/canada-goose.php">Canada Goose</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/canvasback.php">Canvasback</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/cinnamon-teal.php">Cinnamon Teal</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/common-eider.php">Common Eider</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/common-goldeneye.php">Common Goldeneye</a></li>
+        	  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/common-merganser.php">Common Merganser</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/gadwall.php">Gadwall</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/greater-scaup.php">Greater Scaup</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/green-winged-teal.php">Green-winged Teal</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/harlequin-duck.php">Harlequin Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/hooded-merganser.php">Hooded Merganser</a></li>
+        	  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/king-eider.php">King Eider</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/lesser-scaup.php">Lesser Scaup</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/long-tailed-duck.php">Long-tailed Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/mallard.php">Mallard</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/mottled-duck.php">Mottled Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/northern-pintail.php">Northern Pintail</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/northern-shoveler.php">Northern Shoveler</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/red-breasted-merganser.php">Red-breasted Merganser</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/redhead.php">Redhead</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/ring-necked-duck.php">Ring-necked Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/ruddy-duck.php">Ruddy Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/snow-goose.php">Snow Goose</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/surf-scoter.php">Surf Scoter</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/trumpeter-swan.php">Trumpeter Swan</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/tundra-swan.php">Tundra Swan</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/whistling-duck.php">Whistling Duck</a></li>
+        	  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/white-fronted-goose.php">White-fronted Goose</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/white-winged-scoter.php">White-winged Scoter</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/wood-duck.php">Wood Duck</a></li>
+			</ul>
+         </li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/finding-birds.php">Finding Birds</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/festivals-and-events.php">Festivals &amp; Events</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/birdwalk.php">Bird Walks</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/youth-birding.php">Youth Birding</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/bird-watching-tools.php">Bird Watching Tools</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/valuing-birds.php">Economic Impact</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/bird-enthusiasts/hunting.php">Hunting</a></li>
+      <li><a href="/birds/bird-enthusiasts/backyard.php">Backyard Birding</a></li>
+      <li><a href="/birds/bird-enthusiasts/threats-to-birds.php">Threats to Birds</a>
+        <ul>
+          <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions.php">Collisions</a>
+            <ul>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/buildings-and-glass.php">Buildings &amp; Glass</a></li>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/road-vehicles.php">Road Vehicles</a></li>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/aircrafts.php">Aircraft</a></li>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/electric-utility-lines.php">Electric Utility Lines</a></li>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/communication-towers.php">Communication Towers</a></li>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/wind-turbines.php">Wind Turbines</a></li>
+            </ul>
+          </li>
+<li><a href="/birds/bird-enthusiasts/threats-to-birds/disease.php">Disease</a></li>
+          <li><a href="/birds/bird-enthusiasts/threats-to-birds/entrapment-entanglement-drowning.php">Entrapment, Entanglement &amp; Drowning</a></li>
+          <li><a href="/birds/bird-enthusiasts/threats-to-birds/electrocutions.php">Electrocutions</a></li>
+          <li><a href="/birds/bird-enthusiasts/threats-to-birds/habitat-impacts.php">Habitat Impacts</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/faqs.php">FAQs/Commonly Asked Questions</a></li>
+      <li><a href="/birds/about-us/timeline.php">Bird Conservation Timeline</a></li>
+    </ul>
+  </li>
+  
+  <li><a href="/birds/surveys-and-data.php">Surveys &amp; Data</a>
+    <ul>
+      <li><a href="/birds/surveys-and-data/population-surveys.php">Population Surveys</a>
+        <ul>
+          <li><a href="/birds/surveys-and-data/population-surveys/aerial-ground-crew-blog.php">Aerial &amp; Ground Crew Blog</a></li>
+        </ul>
+        </li>
+      <li><a href="/birds/surveys-and-data/bird-banding.php">Bird Banding</a>
+        <ul>
+          <li><a href="/birds/surveys-and-data/bird-banding/reporting-banded-birds.php">Reporting Banded Birds</a></li>
+          <li><a href="/birds/surveys-and-data/bird-banding/reward-bands.php">Reward Bands</a></li>
+          <li><a href="/birds/surveys-and-data/bird-banding/waterfowl-banding-blog.php">Waterfowl Banding Blog</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/surveys-and-data/harvest-surveys.php">Harvest Surveys</a>
+        <ul>
+          <li><a href="/birds/surveys-and-data/harvest-surveys/harvest-information-program.php">Harvest Information Program</a></li>
+          <li><a href="/birds/surveys-and-data/harvest-surveys/diary-surveys.php">Diary Surveys</a></li>
+          <li><a href="/birds/surveys-and-data/harvest-surveys/parts-collection-surveys.php">Parts Collection Surveys</a>          </li>
+              <li><a href="/birds/surveys-and-data/harvest-surveys/bird-and-wing-id.php">Bird &amp; Wing ID</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/surveys-and-data/webless-migratory-game-birds.php">Webless Migratory Game Birds</a>
+        <ul>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/webless-migratory-game-bird-program.php">Webless Migratory Game Bird Program</a>
+            <ul>
+              <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/webless-migratory-game-bird-program/request-for-proposals.php">Request for Proposals</a></li>
+              <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/webless-migratory-game-bird-program/project-abstracts.php">Project Abstracts</a></li>
+            </ul>
+          </li>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/priority-information-needs.php">Priority Information Needs</a></li>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/american-woodcock.php">American Woodcock</a></li>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/doves-and-pigeons.php">Doves &amp; Pigeons</a></li>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/sandhill-cranes.php">Sandhill Cranes</a></li>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/marshbirds.php">Marshbirds</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/surveys-and-data/migratory-bird-data-center.php">Migratory Bird Data Center</a></li>
+      <li><a href="/birds/surveys-and-data/aviation.php">Aviation</a></li>
+      <li><a href="/birds/surveys-and-data/reports-and-publications.php">Reports &amp; Publications</a>
+        <ul>
+          <li><a href="/birds/surveys-and-data/reports-and-publications/population-status.php">Population Status</a></li>
+          <li><a href="/birds/surveys-and-data/reports-and-publications/hunting-activity-and-harvest.php">Hunting Activity &amp; Harvest</a></li>
+          <li><a href="/birds/surveys-and-data/reports-and-publications/flyway-data-books.php">Flyway Data Books</a></li>
+          <li><a href="/birds/management/adaptive-harvest-management/publications-and-reports.php">Adaptive Harvest Management Report</a>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  
+  <li><a href="/birds/management.php">Management</a>
+    <ul>
+      <li><a href="/birds/management/managed-species.php">Managed Species</a>
+        <ul>
+          <li><a href="/birds/management/managed-species/bald-and-golden-eagle-information.php">Bald &amp; Golden Eagle Information</a>
+          <ul>
+          <li><a href="/birds/management/managed-species/eagle-management.php">Eagle Management</a></li>
+          </ul>
+          <li><a href="/birds/management/managed-species/migratory-bird-treaty-act-protected-species.php">Migratory Bird Treaty Act Protected Species (10.13 List)</a></li>
+              <li><a href="/birds/management/managed-species/birds-of-conservation-concern.php">Birds of Conservation Concern</a></li>
+              <li><a href="/birds/management/managed-species/focal-species.php">Focal Species</a></li>
+              <li><a href="/birds/management/managed-species/birds-of-management-concern.php">Birds of Management Concern</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/bird-enthusiasts/threats-to-birds.php">Managing Threats to Birds</a></li>
+      <li><a href="/birds/policies-and-regulations/incidental-take.php">Managing Incidental Take</a>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance.php">Project Assessment Tools &amp; Guidance</a>
+        <ul>
+          <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents.php">Guidance Documents</a>
+            <ul>
+              <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/communication-towers.php">Communication Tower</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/electric-utility-lines.php">Electric Utility Line</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/oil-and-gas.php">Oil &amp; Gas</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/wind-energy.php">Wind Energy</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/eagles.php">Eagles</a></li>
+            </ul>
+          </li>
+          <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures.php">Conservation Measures</a>
+          <ul>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/nationwide-standard-conservation-measures.php">Nationwide Conservation Measures</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/building-glass-and-lighting.php">Buildings, Glass &amp; Lighting</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/communication-towers.php">Communication Towers</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/coal-bed-methane.php">Coal-bed Methane</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/hunting-and-fishing.php">Hunting &amp; Fishing</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/electric-utility.php">Electric Utility</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/fluid-minerals.php">Fluid Mineral Practices</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/mining-claim-markers.php">Mining Claim Markers</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/outdoor-lighting.php">Outdoor Lighting</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/transportation.php">Transportation</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/vegetation-management.php">Vegetation Management</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/wind-energy.php">Wind Energy</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/eagles.php">Eagles</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/sage-grouse.php">Sage-Grouse</a></li>
+            </ul>
+            </li>
+          <li><a href="/birds/management/project-assessment-tools-and-guidance/decision-support-tools.php">Decision Support Tools</a>
+          <ul>
+              <li><a href="/birds/management/project-assessment-tools-and-guidance/decision-support-tools/akn-histogram-tools.php">Avian Knowledge Network Histogram Tools</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/decision-support-tools/imr.php">Injury and Mortality Reporting System</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/decision-support-tools/ipac.php">Information for Planning and Conservation System</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/decision-support-tools/bird-data-and-information.php">Other Bird Data and Information Resources</a></li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li><a href="/birds/management/adaptive-harvest-management.php">Adaptive Harvest Management</a>
+        <ul>
+          <li><a href="/birds/management/adaptive-harvest-management/publications-and-reports.php">Publications &amp; Reports</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/management/flyways.php">Flyways</a></li>
+      <li><a href="/birds/management/bird-management-plans.php">Bird Management Plans</a>
+        <ul>
+          <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan.php">North American Waterfowl Management Plan</a>
+           <ul>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/integrating-waterfowl-management.php">Integrating Waterfowl Management</a></li>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/plan-committee.php">Plan Committee</a></li>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/working-groups-and-subcommittees.php">Working Groups &amp; Subcommittees</a></li>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/plan-documents.php">Plan Documents</a></li>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/plan-awards.php">Plan Awards</a></li>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/nawmp-science-support-team.php">NAWMP Science Support Team</a></li>
+            </ul>
+            </li>
+          <li><a href="/birds/management/bird-management-plans/partners-in-flight-north-american-landbird-conservation-plan.php">Partners in Flight North American Landbird Conservation Plan</a></li>
+          <li><a href="/birds/management/bird-management-plans/waterbird-conservation-for-the-americas.php">Waterbird Conservation for the Americas</a></li>
+          <li><a href="/birds/management/bird-management-plans/the-us-shorebird-conservation-plan.php">The U.S. Shorebird Conservation Plan</a></li>
+          <li><a href="/birds/management/managed-species/focal-species.php">Focal Species Plans</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/management/bird-conservation-partnership-and-initiatives.php">Bird Conservation Partnerships &amp; Initiatives</a>
+        <ul>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds.php">Council for the Conservation of Migratory Birds</a>
+            <ul>
+                        <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds/participating-council-agencies.php">Participating Council Agencies</a></li>
+                        <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds/partnership-agreements.php">Partnership Agreements</a></li>
+                        <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds/council-annual-reports.php">Council Annual Reports</a></li>
+                        <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds/presidential-award.php">Presidential Award</a></li>
+                        <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds/council-newsletter.php">Council Newsletter</a></li>
+                    
+            </ul>
+          </li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/migratory-bird-joint-ventures.php">Migratory Bird Joint Ventures</a>
+          <ul>
+              <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/migratory-bird-joint-ventures/joint-venture-directory.php">Joint Venture Directory</a></li>
+              <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/migratory-bird-joint-ventures/map-products.php">Map Products</a></li>
+              <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/migratory-bird-joint-ventures/policy.php">Policy</a></li>
+            </ul>
+          </li>
+            <li><a href="/birds/management/flyways.php">Migratory Bird Flyways</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/north-american-bird-conservation-initiative.php">North American Bird Conservation Initiative</a></li>
+          <li><a href="/birds/grants/urban-bird-treaty.php">Urban Bird Treaty Program</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/shorebird-conservation.php">Shorebird Conservation</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/waterbird-conservation.php">Waterbird Conservation</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/partners-in-flight.php">Partners in Flight</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/waterfowl-conservation.php">Waterfowl Conservation</a></li>
+          <li><a href="/birds/about-us/International.php">International Cooperation</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/partners.php">Other Partners</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/management/training.php">Training</a>
+        <ul>
+          <li><a href="/birds/management/training/migratory-bird-conservation-a-trust-responsibility.php">Migratory Bird Conservation: A Trust Responsibility</a></li>
+          <li><a href="/birds/management/training/migratory-bird-conservation-for-federal-partners.php">Migratory Bird Conservation for Federal Partners</a></li>
+          <li><a href="/birds/management/training/basic-bird-biology.php">Basic Bird Biology</a></li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  
+  <li><a href="/birds/grants.php">Grants</a>
+    <ul>
+      <li><a href="/birds/grants/north-american-wetland-conservation-act.php">North American Wetlands Conservation Act</a>
+        <ul>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/how-to-apply-for-a-nawca-grant.php">How to Apply for a NAWCA Grant</a></li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/information-for-nawca-grantees.php">Information for NAWCA Grantees</a>
+            <ul>
+              <li><a href="/birds/grants/north-american-wetland-conservation-act/information-for-nawca-grantees/guidance-and-standards.php">Guidance &amp; Standards</a></li>
+              <li><a href="/birds/grants/north-american-wetland-conservation-act/information-for-nawca-grantees/forms.php">Forms</a></li>
+            </ul>
+          </li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/standard-grants.php">Standard Grants</a>
+            <ul>
+              <li><a href="/birds/grants/north-american-wetland-conservation-act/standard-grants/united-states.php">United States</a></li>
+              <li><a href="/birds/grants/north-american-wetland-conservation-act/standard-grants/canada.php">Canada</a></li>
+              <li><a href="/birds/grants/north-american-wetland-conservation-act/standard-grants/mexico.php">Mexico</a></li>
+            </ul>
+          </li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/nawca-project-summaries.php">NAWCA Project Summaries</a></li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/small-grants.php">Small Grants</a></li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/north-american-wetland-conservation-council.php">North American Wetlands Conservation Council</a></li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/biennial-reports.php">Biennial Reports</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act.php">Neotropical Migratory Bird Conservation Act</a>
+        <ul>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/how-to-apply.php">How to Apply</a></li>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/nmbca-project-summaries.php">NMBCA Project Summaries</a></li>
+         
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/information-for-nmbca-grantees.php">Information for NMBCA Grantees</a>
+            <ul>
+              <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/information-for-nmbca-grantees/managing-your-grant.php">Managing Your Grant</a></li>
+              <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/information-for-nmbca-grantees/annual-reporting-obligations.php">Annual Reporting Obligations</a></li>
+              <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/information-for-nmbca-grantees/grant-guidelines.php">Grant Guidelines</a></li>
+              <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/information-for-nmbca-grantees/faq.php">FAQ</a></li>
+            </ul>
+          </li>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/advisory-group.php">Advisory Group</a></li>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/nmbca-bird-list.php">NMBCA Bird List</a></li>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/communications-toolkit.php">Communications Toolkit</a></li>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/nmbca-espanol.php">En Español</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/grants/urban-bird-treaty.php">Urban Bird Treaty</a>
+        <ul>
+          <li><a href="/birds/grants/urban-bird-treaty/urban-bird-treaty-grant.php">Urban Bird Treaty Grant Information</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/grants/funding-sources-and-how-to-apply.php">Funding Sources &amp; How to Apply</a>
+      <ul>
+      <li><a href="/birds/grants/urban-bird-treaty/urban-bird-treaty-grant.php">Urban Bird Treaty Grant Information</a></li>
+      <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/webless-migratory-game-bird-program/request-for-proposals.php">Webless Migratory Game Bird Program</a></li>
+      </ul>
+      </li>
+      <li><a href="/birds/grants/payments.php">Payments</a></li>
+    </ul>
+  </li>
+  
+  <li><a href="/birds/education.php">Education</a>
+    <ul>
+      <li><a href="/birds/education/junior-duck-stamp-conservation-program.php">Junior Duck Stamp Conservation Program</a>
+        <ul>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/buy-junior-duck-stamps.php">Buy Junior Duck Stamps</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/conservation-education-curriculum.php">Conservation Education Curriculum</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/junior-duck-stamp-contest-information.php">Junior Duck Stamp Contest Information</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/junior-duck-stamp-in-your-state.php">Junior Duck Stamp in Your State</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/junior-duck-stamp-gallery.php">Junior Duck Stamp Gallery</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/junior-duck-stamp-art-tour.php">Junior Duck Stamp Art Exhibit Tour</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/education/education-resources.php">Education Resources</a>
+        <ul>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/youth-birding.php">Youth Birding</a></li>
+          <li><a href="/birds/education/education-resources/educators.php">Educators</a></li>
+          <li><a href="/birds/education/education-resources/parents.php">Parents</a></li>
+          <li><a href="/birds/education/education-resources/fact-sheets.php">Fact Sheets</a></li>
+          <li><a href="/birds/education/education-resources/multimedia.php">Multimedia</a></li>
+          <li><a href="/birds/education/education-resources/educational-activities.php">Activities</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/grants/urban-bird-treaty.php">Urban Birds</a></li>
+      <li><a href="/birds/education/international-migratory-bird-day.php">International Migratory Bird Day</a></li>
+    </ul>
+  </li>
+  
+  <li><a href="/birds/get-involved.php">Get Involved</a>
+    <ul>
+      <li><a href="/birds/get-involved/duck-stamp.php">Duck Stamp</a>
+        <ul>
+          <li><a href="/birds/get-involved/duck-stamp/history-of-the-federal-duck-stamp.php">History of the Federal Duck Stamp</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/buy-duck-stamp.php">Buy Duck Stamps</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/e-stamp.php">E-Stamp</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-dollars-at-work.php">Duck Stamp Dollars at Work</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-contest-and-event-information.php">Duck Stamp Contest &amp; Event Information</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-information-for-hunters.php">Duck Stamp Information for Hunters</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-information-for-birders-and-photographers.php">Duck Stamp Information for Birders &amp; Photographers</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-information-for-stamp-collectors.php">Duck Stamp Information for Stamp Collectors</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/sell-duck-stamp.php">Sell Duck Stamps</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/federal-duck-stamp-gallery.php">Federal Duck Stamp Gallery</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/federal-duck-stamp-art-exhibit-tour.php">Federal Duck Stamp Art Exhibit Tour</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-design-products-and-licensing-program.php">Duck Stamp Design Products &amp; Licensing Program</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program.php">Junior Duck Stamp Conservation Program</a>
+        </ul>
+      </li>
+      <li><a href="/birds/get-involved/invest-in-conservation.php">Invest in Conservation</a>
+        <ul>
+          <li><a href="/birds/get-involved/invest-in-conservation/donate.php">Donate</a></li>
+          <li><a href="/birds/get-involved/invest-in-conservation/provide-matching-funds.php">Provide Matching Funds</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/get-involved/citizen-science.php">Citizen Science</a></li>
+      <li><a href="/birds/get-involved/engaging-others.php">Engaging Others</a>
+        <ul>
+          <li><a href="/birds/get-involved/engaging-others/event.php">Special Event Tips & Examples</a></li>
+          <li><a href="/birds/get-involved/engaging-others/getting-publicity.php">Getting Publicity for Your Event</a></li>
+          <li><a href="/birds/get-involved/engaging-others/partnerships.php">Building Partnerships</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/about-us/strategicplan.php">Strategic Plan</a></li>
+    </ul>
+  </li>
+  
+  <li class="last submenus-left"><a href="/birds/policies-and-regulations.php">Policies &amp; Regulations</a>
+    <ul>
+      <li><a href="/birds/policies-and-regulations/laws-legislations.php">Laws/Legislation</a>
+        <ul>
+          <li><a href="/birds/policies-and-regulations/laws-legislations/migratory-bird-treaty-act.php">Migratory Bird Treaty Act</a></li>
+          <li><a href="/birds/policies-and-regulations/laws-legislations/migratory-bird-hunting-and-conservation-stamp-act.php">Migratory Bird Hunting &amp; Conservation Stamp Act</a></li>
+          <li><a href="/birds/policies-and-regulations/laws-legislations/bald-and-golden-eagle-protection-act.php">Bald &amp; Golden Eagle Protection Act</a></li>
+          <li><a href="/birds/policies-and-regulations/laws-legislations/other-relevant-laws.php">Other Relevant Laws</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/policies-and-regulations/policies.php">Policies</a></li>
+      <li><a href="/birds/policies-and-regulations/regulations.php">Regulations</a>
+        <ul>
+          <li><a href="/birds/policies-and-regulations/regulations/migratory-bird-hunting-regulations.php">Migratory Bird Hunting Regulations</a></li>
+          <li><a href="/birds/policies-and-regulations/regulations/national-environmental-policy-act.php">National Environmental Policy Act</a></li>
+          <li><a href="/birds/policies-and-regulations/regulations/how-regulations-are-set-the-process.php">How Regulations Are Set - The Process</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/policies-and-regulations/executive-orders.php">Executive Orders</a>
+        <ul>
+          <li><a href="/birds/policies-and-regulations/executive-orders/e0-13186.php">EO 13186</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/policies-and-regulations/federal-register-notices.php">Federal Register Notices</a></li>
+      <li><a href="/birds/policies-and-regulations/permits.php">Permits</a>
+        <ul>
+          <li><a href="/birds/policies-and-regulations/permits/regional-permit-contacts.php">Regional Permit Contacts</a></li>
+          <li><a href="/birds/policies-and-regulations/permits/permit-policies-and-regulations.php">Permit Policies &amp; Regulations</a></li>
+          <li><a href="/birds/policies-and-regulations/permits/need-a-permit.php">Need a Permit</a></li>
+        </ul>
+      </li>
+    <li><a href="/birds/policies-and-regulations/incidental-take.php">Incidental Take</a></ul>
+  </li>  
+</ul>			</nav>
+		</div>
+	</div>
+    </header>
+
+
+
+
+<!--Home Hero-->
+<div id="home-hero">
+	<div class="hero-wrap">
+		<figure>
+    <!-- InstanceBeginEditable name="Hero Image" -->
+    <!--please note that this uses responsive images-->
+    <span data-picture data-alt="">
+      <span data-src="/birdhabitat/img/home-hero/impact-02-mobile.png"></span>
+      <span data-src="/birdhabitat/img/home-hero/impact-02-desktop.png" data-media="(min-width: 481px)"></span>
+      <span data-src="/birdhabitat/img/home-hero/impact-02-fullscreen.png" data-media="(min-width: 1320px)"></span>
+      <noscript><img src="/birdhabitat/img/home-hero/impact-02-mobile.png" alt="Gadwall_GaryKramer"></noscript>
+    </span>
+    <!-- InstanceEndEditable -->
+    </figure>
+		<div class="hero-content">
+    <!-- InstanceBeginEditable name="Hero Content" -->
+		  <h1>2017 Federal Duck Stamp Art Contest!</h1>
+      <p>Bob Hautman Wins Federal Duck Stamp Contest</p>
+      <p class="button"><a href="news/170916duck-stamp.php" class="blue-button">Learn more</a></p>
+		<!-- InstanceEndEditable -->
+    </div>
+	</div>
+</div>
+
+<!--Driver to Persona Pages-->
+<div class="what-matters">
+  <div class="wrap">
+    <h2>What Matters Most?</h2>
+<div class="jump-nav">
+  <div class="label">Migratory bird resources just for you: <span>I am</span></div>
+  <div class="i-am">I am</div>
+  <div class="menu">
+    <ul>
+      <li><a href="#">select one...</a>
+        <ul>
+          <li><a href="/birds/partner.php">a partner</a></li>
+          <li><a href="/birds/hunter.php">a hunter</a></li>
+          <li><a href="/birds/birder.php">a birder</a></li>
+          <li><a href="/birds/artist.php">an artist</a></li>
+          <li><a href="/birds/media.php">the media</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</div>  </div>
+</div>
+
+
+<!--Main Call To Actions / Content -->
+<section class="cta">
+	<div class="wrap">
+  <!-- InstanceBeginRepeat name="Home CTAs" --><!-- InstanceBeginRepeatEntry -->
+	  <article>
+	    <figure>
+      <!-- InstanceBeginEditable name="CTA Image" -->
+      <!--Please note that this uses responsive images-->
+      <span data-picture data-alt="">
+		  <span data-src="/birdhabitat/img/home-cta/commtower-mobile.jpg"></span>
+		  <span data-src="/birdhabitat/img/home-cta/commtower.jpg" data-media="(min-width: 481px)"></span>
+					<noscript><img src="/birdhabitat/img/home-cta/commtower-mobile.jpg" alt="Coast Guard members participating in the tower climb training rotate through the begining stages of rescue training by ascending and descending from the 150-foot point of the 300-foot tower at Communications Station Kodiak Aug. 25, 2003, in Kodiak, Alaska. U.S. Coast Guard photo by Petty officer 3rd Class Sara Raymer." /></noscript>
+		  </span>
+      <!-- InstanceEndEditable -->
+      </figure>
+      <div class="text">
+        <h3><!-- InstanceBeginEditable name="CTA Title" --><strong>Communication Towers</strong><!-- InstanceEndEditable --></h3>
+        <!-- InstanceBeginEditable name="CTA Content" -->
+	    <p>Communication towers are in the <a href="bird-enthusiasts/threats-to-birds.php">list of top human-caused threats to birds</a>. The good news is, there are some things that tower owners and operators can do to ensure towers are minimizing the impacts to birds. Some of these solutions even save maintenance costs for tower owners. These recommendations can be both <a href="../migratorybirds/pdf/management/usfwscommtowerguidance.pdf" class="pdf file-icons"><span class="icon">&nbsp;</span>proactive (340.3KB)</a> and <a href="../migratorybirds/pdf/management/fccopportunitiestoreducebirdcollisions.pdf" class="pdf file-icons"><span class="icon">&nbsp;</span>retroactive (219.2KB)</a> in nature.</p>
+	    <!-- InstanceEndEditable -->
+      </div>
+      <div class="button"><!-- InstanceBeginEditable name="CTA Link" --><a href="bird-enthusiasts/threats-to-birds/collisions/communication-towers.php" class="blue-button"> Learn More</a><!-- InstanceEndEditable --></div>
+    </article>
+	<!-- InstanceEndRepeatEntry --><!-- InstanceBeginRepeatEntry -->
+	  <article>
+	    <figure>
+      <!-- InstanceBeginEditable name="CTA Image" -->
+      <!--Please note that this uses responsive images-->
+        <span data-picture data-alt="">
+					<span data-src="/birdhabitat/img/home-cta/permit-ospreyMarvinDeJongUSFWS-mobile.jpg"></span>
+					<span data-src="/birdhabitat/img/home-cta/permit-ospreyMarvinDeJongUSFWS.jpg" data-media="(min-width: 481px)"></span>
+					<noscript><img src="/birdhabitat/img/home-cta/permit-ospreyMarvinDeJongUSFWS-mobile.jpg" alt="2016 Jr. Duck Stamp
+/USFWS"/></noscript>
+		  </span>
+      <!-- InstanceEndEditable -->
+      </figure>
+      <div class="text">
+        <h3><!-- InstanceBeginEditable name="CTA Title" -->​<strong>Need a Permit</strong><!-- InstanceEndEditable --></h3>
+        <!-- InstanceBeginEditable name="CTA Content" -->
+	    <p>Permits provide a means to balance use and conservation of protected species. Permits can be important as a conservation tool, to promote long-term conservation of animals, plants, and their habitats, and encourage joint stewardship with others.</p>
+	    <!-- InstanceEndEditable -->
+      </div>
+      <div class="button"><!-- InstanceBeginEditable name="CTA Link" --><a href="policies-and-regulations/permits.php" class="blue-button">Learn More!</a><!-- InstanceEndEditable --></div>
+    </article>
+	<!-- InstanceEndRepeatEntry --><!-- InstanceBeginRepeatEntry -->
+	  <article>
+	    <figure>
+      <!-- InstanceBeginEditable name="CTA Image" -->
+      <!--Please note that this uses responsive images-->
+        <span data-picture data-alt="">
+		  <span data-src="/birdhabitat/img/home-cta/duck-stamp-contest-mobile.jpg"></span>
+		  <span data-src="/birdhabitat/img/home-cta/duck-stamp-contest.jpg" data-media="(min-width: 481px)"></span>
+					<noscript><img src="/birdhabitat/img/home-cta/duck-stamp-contest-mobile.jpg" alt="Judges voting." /></noscript>
+		  </span>
+      <!-- InstanceEndEditable -->
+      </figure>
+      <div class="text">
+        <h3><!-- InstanceBeginEditable name="CTA Title" --><strong>Art &amp; Wildlife Collide</strong><!-- InstanceEndEditable --></h3>
+        <!-- InstanceBeginEditable name="CTA Content" -->
+	    <p>The nation's oldest and most prestigious wildlife art contest takes place Sept. 15 &amp; 16 in Stevens Point, WI. Whose art will grace the 2018-2019 Federal Duck Stamp, which will raise millions of dollars for conservation? Join us in person or online to see.</p>
+	    <!-- InstanceEndEditable -->
+      </div>
+      <div class="button"><!-- InstanceBeginEditable name="CTA Link" --><a href="get-involved/duck-stamp/duck-stamp-contest-and-event-information.php" class="blue-button"> Learn More</a><!-- InstanceEndEditable --></div>
+    </article>
+	<!-- InstanceEndRepeatEntry --><!-- InstanceEndRepeat --></div>
+</section>
+
+
+<!--news-->
+<div class="news" id="home-news">
+	<div class="wrap">
+		<header>
+			<h2>Featured News</h2>
+			<div class="more-news">
+				<ul>
+					<li class="all-news"><a href="/birds/news.php">All News</a></li>
+					<li class="facebook"><a href="https://www.facebook.com/usfwsmigratorybirds" title="Link to non-FWS site"><i class="fa fa-facebook fa-fw"></i></a></li>
+					<li class="twitter"><a href="https://twitter.com/usfwsbirds" title="Link to non-FWS site"><i class="fa fa-twitter fa-fw"></i></a></li>
+				</ul>
+			</div>
+		</header>
+		<!-- InstanceBeginEditable name="News" -->
+		
+    <!--wrap up to 3 items per "row"-->
+   <div class="row first">
+     <div class="item">
+				<a href="/birds/news/171025hautman-brothers.php">
+					<span class="date">October 25, 2017</span>
+					<span class="title h3">View all 13 of the Hautman brothers' Original Winning Duck Stamp Paintings</span>
+				</a>
+        </div>
+      <div class="item">
+				<a href="/birds/news/170916duck-stamp.php">
+					<span class="date">September 16, 2017</span>
+					<span class="title h3">Minnesota Artist Bob Hautman Wins 2017 Federal Duck Stamp Art Contest</span>
+				</a>
+        </div>
+       <div class="item">
+				<a href="/birds/news/170908press-release.php">
+					<span class="date">September 9, 2017</span>
+					<span class="title h3">North American Wetlands Conservation Act Grants Announced</span>
+				</a>
+        </div>
+		</div>
+              <!--end row--> 
+              
+               <!--start row-->
+               <div class="row">
+               <div class="item">
+				<a href="/birds/news/170901adaptiveharvestmanagement.php">
+					<span class="date">September 1, 2017</span>
+					<span class="title h3">Adaptive Harvest Management Report for 2018 Hunting Season</span>
+				</a>
+        </div>
+        <div class="item">
+				<a href="/birds/news/170829duck-stamps-contest.php">
+					<span class="date">August 29, 2017</span>
+					<span class="title h3">Witness History at the 2017 Federal Duck Stamp Art Contest</span>
+				</a>
+        </div>
+    <div class="item">
+				<a href="/birds/news/170824SOTB.php">
+					<span class="date">August 24, 2017</span>
+					<span class="title h3">Report Shows Farm Bill Benefits to Birds</span>
+				</a>
+        </div>
+	   </div>
+    <!--end row-->
+    
+    <!-- InstanceEndEditable -->
+    
+  </div>
+</div>
+
+
+<div id="update"><div class="wrap">
+  <p>Last Updated: <!-- #BeginDate format:Am1 -->October 25, 2017<!-- #EndDate --></p>
+</div></div>
+
+<footer id="framework-footer">
+
+	<div id="smartfooter">
+		<div class="wrap">
+			<nav>
+<ul>
+	<li class="first"><a href="/birds/bird-enthusiasts.php">Bird Enthusiasts</a>
+    <ul>
+      <li><a href="/birds/bird-enthusiasts/bird-watching.php">Bird Watching</a>
+        <ul>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/bird-identification.php">Bird Identification</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification.php">Waterfowl Identification</a>
+          	<ul>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/american-black-duck.php">American Black Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/american-wigeon.php">Aerican Wigeon</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/barrows-goldeneye.php">Barrows Goldeneye</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/black-scoter.php">Black Scoter</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/blue-winged-teal.php">Blue-winged Teal</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/brant.php">Brant</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/bufflehead.php">Bufflehead</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/canada-goose.php">Canada Goose</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/canvasback.php">Canvasback</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/cinnamon-teal.php">Cinnamon Teal</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/common-eider.php">Common Eider</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/common-goldeneye.php">Common Goldeneye</a></li>
+        	  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/common-merganser.php">Common Merganser</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/gadwall.php">Gadwall</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/greater-scaup.php">Greater Scaup</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/green-winged-teal.php">Green-winged Teal</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/harlequin-duck.php">Harlequin Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/hooded-merganser.php">Hooded Merganser</a></li>
+        	  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/king-eider.php">King Eider</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/lesser-scaup.php">Lesser Scaup</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/long-tailed-duck.php">Long-tailed Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/mallard.php">Mallard</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/mottled-duck.php">Mottled Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/northern-pintail.php">Northern Pintail</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/northern-shoveler.php">Northern Shoveler</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/red-breasted-merganser.php">Red-breasted Merganser</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/redhead.php">Redhead</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/ring-necked-duck.php">Ring-necked Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/ruddy-duck.php">Ruddy Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/snow-goose.php">Snow Goose</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/surf-scoter.php">Surf Scoter</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/trumpeter-swan.php">Trumpeter Swan</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/tundra-swan.php">Tundra Swan</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/whistling-duck.php">Whistling Duck</a></li>
+        	  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/white-fronted-goose.php">White-fronted Goose</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/white-winged-scoter.php">White-winged Scoter</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/wood-duck.php">Wood Duck</a></li>
+			</ul>
+         </li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/finding-birds.php">Finding Birds</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/festivals-and-events.php">Festivals &amp; Events</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/birdwalk.php">Bird Walks</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/youth-birding.php">Youth Birding</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/bird-watching-tools.php">Bird Watching Tools</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/valuing-birds.php">Economic Impact</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/bird-enthusiasts/hunting.php">Hunting</a></li>
+      <li><a href="/birds/bird-enthusiasts/backyard.php">Backyard Birding</a></li>
+      <li><a href="/birds/bird-enthusiasts/threats-to-birds.php">Threats to Birds</a>
+        <ul>
+          <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions.php">Collisions</a>
+            <ul>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/buildings-and-glass.php">Buildings &amp; Glass</a></li>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/road-vehicles.php">Road Vehicles</a></li>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/aircrafts.php">Aircraft</a></li>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/electric-utility-lines.php">Electric Utility Lines</a></li>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/communication-towers.php">Communication Towers</a></li>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/wind-turbines.php">Wind Turbines</a></li>
+            </ul>
+          </li>
+<li><a href="/birds/bird-enthusiasts/threats-to-birds/disease.php">Disease</a></li>
+          <li><a href="/birds/bird-enthusiasts/threats-to-birds/entrapment-entanglement-drowning.php">Entrapment, Entanglement &amp; Drowning</a></li>
+          <li><a href="/birds/bird-enthusiasts/threats-to-birds/electrocutions.php">Electrocutions</a></li>
+          <li><a href="/birds/bird-enthusiasts/threats-to-birds/habitat-impacts.php">Habitat Impacts</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/faqs.php">FAQs/Commonly Asked Questions</a></li>
+      <li><a href="/birds/about-us/timeline.php">Bird Conservation Timeline</a></li>
+    </ul>
+  </li>
+  
+  <li><a href="/birds/surveys-and-data.php">Surveys &amp; Data</a>
+    <ul>
+      <li><a href="/birds/surveys-and-data/population-surveys.php">Population Surveys</a>
+        <ul>
+          <li><a href="/birds/surveys-and-data/population-surveys/aerial-ground-crew-blog.php">Aerial &amp; Ground Crew Blog</a></li>
+        </ul>
+        </li>
+      <li><a href="/birds/surveys-and-data/bird-banding.php">Bird Banding</a>
+        <ul>
+          <li><a href="/birds/surveys-and-data/bird-banding/reporting-banded-birds.php">Reporting Banded Birds</a></li>
+          <li><a href="/birds/surveys-and-data/bird-banding/reward-bands.php">Reward Bands</a></li>
+          <li><a href="/birds/surveys-and-data/bird-banding/waterfowl-banding-blog.php">Waterfowl Banding Blog</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/surveys-and-data/harvest-surveys.php">Harvest Surveys</a>
+        <ul>
+          <li><a href="/birds/surveys-and-data/harvest-surveys/harvest-information-program.php">Harvest Information Program</a></li>
+          <li><a href="/birds/surveys-and-data/harvest-surveys/diary-surveys.php">Diary Surveys</a></li>
+          <li><a href="/birds/surveys-and-data/harvest-surveys/parts-collection-surveys.php">Parts Collection Surveys</a>          </li>
+              <li><a href="/birds/surveys-and-data/harvest-surveys/bird-and-wing-id.php">Bird &amp; Wing ID</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/surveys-and-data/webless-migratory-game-birds.php">Webless Migratory Game Birds</a>
+        <ul>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/webless-migratory-game-bird-program.php">Webless Migratory Game Bird Program</a>
+            <ul>
+              <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/webless-migratory-game-bird-program/request-for-proposals.php">Request for Proposals</a></li>
+              <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/webless-migratory-game-bird-program/project-abstracts.php">Project Abstracts</a></li>
+            </ul>
+          </li>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/priority-information-needs.php">Priority Information Needs</a></li>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/american-woodcock.php">American Woodcock</a></li>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/doves-and-pigeons.php">Doves &amp; Pigeons</a></li>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/sandhill-cranes.php">Sandhill Cranes</a></li>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/marshbirds.php">Marshbirds</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/surveys-and-data/migratory-bird-data-center.php">Migratory Bird Data Center</a></li>
+      <li><a href="/birds/surveys-and-data/aviation.php">Aviation</a></li>
+      <li><a href="/birds/surveys-and-data/reports-and-publications.php">Reports &amp; Publications</a>
+        <ul>
+          <li><a href="/birds/surveys-and-data/reports-and-publications/population-status.php">Population Status</a></li>
+          <li><a href="/birds/surveys-and-data/reports-and-publications/hunting-activity-and-harvest.php">Hunting Activity &amp; Harvest</a></li>
+          <li><a href="/birds/surveys-and-data/reports-and-publications/flyway-data-books.php">Flyway Data Books</a></li>
+          <li><a href="/birds/management/adaptive-harvest-management/publications-and-reports.php">Adaptive Harvest Management Report</a>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  
+  <li><a href="/birds/management.php">Management</a>
+    <ul>
+      <li><a href="/birds/management/managed-species.php">Managed Species</a>
+        <ul>
+          <li><a href="/birds/management/managed-species/bald-and-golden-eagle-information.php">Bald &amp; Golden Eagle Information</a>
+          <ul>
+          <li><a href="/birds/management/managed-species/eagle-management.php">Eagle Management</a></li>
+          </ul>
+          <li><a href="/birds/management/managed-species/migratory-bird-treaty-act-protected-species.php">Migratory Bird Treaty Act Protected Species (10.13 List)</a></li>
+              <li><a href="/birds/management/managed-species/birds-of-conservation-concern.php">Birds of Conservation Concern</a></li>
+              <li><a href="/birds/management/managed-species/focal-species.php">Focal Species</a></li>
+              <li><a href="/birds/management/managed-species/birds-of-management-concern.php">Birds of Management Concern</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/bird-enthusiasts/threats-to-birds.php">Managing Threats to Birds</a></li>
+      <li><a href="/birds/policies-and-regulations/incidental-take.php">Managing Incidental Take</a>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance.php">Project Assessment Tools &amp; Guidance</a>
+        <ul>
+          <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents.php">Guidance Documents</a>
+            <ul>
+              <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/communication-towers.php">Communication Tower</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/electric-utility-lines.php">Electric Utility Line</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/oil-and-gas.php">Oil &amp; Gas</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/wind-energy.php">Wind Energy</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/eagles.php">Eagles</a></li>
+            </ul>
+          </li>
+          <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures.php">Conservation Measures</a>
+          <ul>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/nationwide-standard-conservation-measures.php">Nationwide Conservation Measures</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/building-glass-and-lighting.php">Buildings, Glass &amp; Lighting</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/communication-towers.php">Communication Towers</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/coal-bed-methane.php">Coal-bed Methane</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/hunting-and-fishing.php">Hunting &amp; Fishing</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/electric-utility.php">Electric Utility</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/fluid-minerals.php">Fluid Mineral Practices</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/mining-claim-markers.php">Mining Claim Markers</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/outdoor-lighting.php">Outdoor Lighting</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/transportation.php">Transportation</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/vegetation-management.php">Vegetation Management</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/wind-energy.php">Wind Energy</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/eagles.php">Eagles</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/sage-grouse.php">Sage-Grouse</a></li>
+            </ul>
+            </li>
+          <li><a href="/birds/management/project-assessment-tools-and-guidance/decision-support-tools.php">Decision Support Tools</a>
+          <ul>
+              <li><a href="/birds/management/project-assessment-tools-and-guidance/decision-support-tools/akn-histogram-tools.php">Avian Knowledge Network Histogram Tools</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/decision-support-tools/imr.php">Injury and Mortality Reporting System</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/decision-support-tools/ipac.php">Information for Planning and Conservation System</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/decision-support-tools/bird-data-and-information.php">Other Bird Data and Information Resources</a></li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li><a href="/birds/management/adaptive-harvest-management.php">Adaptive Harvest Management</a>
+        <ul>
+          <li><a href="/birds/management/adaptive-harvest-management/publications-and-reports.php">Publications &amp; Reports</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/management/flyways.php">Flyways</a></li>
+      <li><a href="/birds/management/bird-management-plans.php">Bird Management Plans</a>
+        <ul>
+          <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan.php">North American Waterfowl Management Plan</a>
+           <ul>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/integrating-waterfowl-management.php">Integrating Waterfowl Management</a></li>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/plan-committee.php">Plan Committee</a></li>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/working-groups-and-subcommittees.php">Working Groups &amp; Subcommittees</a></li>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/plan-documents.php">Plan Documents</a></li>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/plan-awards.php">Plan Awards</a></li>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/nawmp-science-support-team.php">NAWMP Science Support Team</a></li>
+            </ul>
+            </li>
+          <li><a href="/birds/management/bird-management-plans/partners-in-flight-north-american-landbird-conservation-plan.php">Partners in Flight North American Landbird Conservation Plan</a></li>
+          <li><a href="/birds/management/bird-management-plans/waterbird-conservation-for-the-americas.php">Waterbird Conservation for the Americas</a></li>
+          <li><a href="/birds/management/bird-management-plans/the-us-shorebird-conservation-plan.php">The U.S. Shorebird Conservation Plan</a></li>
+          <li><a href="/birds/management/managed-species/focal-species.php">Focal Species Plans</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/management/bird-conservation-partnership-and-initiatives.php">Bird Conservation Partnerships &amp; Initiatives</a>
+        <ul>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds.php">Council for the Conservation of Migratory Birds</a>
+            <ul>
+                        <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds/participating-council-agencies.php">Participating Council Agencies</a></li>
+                        <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds/partnership-agreements.php">Partnership Agreements</a></li>
+                        <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds/council-annual-reports.php">Council Annual Reports</a></li>
+                        <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds/presidential-award.php">Presidential Award</a></li>
+                        <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds/council-newsletter.php">Council Newsletter</a></li>
+                    
+            </ul>
+          </li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/migratory-bird-joint-ventures.php">Migratory Bird Joint Ventures</a>
+          <ul>
+              <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/migratory-bird-joint-ventures/joint-venture-directory.php">Joint Venture Directory</a></li>
+              <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/migratory-bird-joint-ventures/map-products.php">Map Products</a></li>
+              <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/migratory-bird-joint-ventures/policy.php">Policy</a></li>
+            </ul>
+          </li>
+            <li><a href="/birds/management/flyways.php">Migratory Bird Flyways</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/north-american-bird-conservation-initiative.php">North American Bird Conservation Initiative</a></li>
+          <li><a href="/birds/grants/urban-bird-treaty.php">Urban Bird Treaty Program</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/shorebird-conservation.php">Shorebird Conservation</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/waterbird-conservation.php">Waterbird Conservation</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/partners-in-flight.php">Partners in Flight</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/waterfowl-conservation.php">Waterfowl Conservation</a></li>
+          <li><a href="/birds/about-us/International.php">International Cooperation</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/partners.php">Other Partners</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/management/training.php">Training</a>
+        <ul>
+          <li><a href="/birds/management/training/migratory-bird-conservation-a-trust-responsibility.php">Migratory Bird Conservation: A Trust Responsibility</a></li>
+          <li><a href="/birds/management/training/migratory-bird-conservation-for-federal-partners.php">Migratory Bird Conservation for Federal Partners</a></li>
+          <li><a href="/birds/management/training/basic-bird-biology.php">Basic Bird Biology</a></li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  
+  <li><a href="/birds/grants.php">Grants</a>
+    <ul>
+      <li><a href="/birds/grants/north-american-wetland-conservation-act.php">North American Wetlands Conservation Act</a>
+        <ul>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/how-to-apply-for-a-nawca-grant.php">How to Apply for a NAWCA Grant</a></li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/information-for-nawca-grantees.php">Information for NAWCA Grantees</a>
+            <ul>
+              <li><a href="/birds/grants/north-american-wetland-conservation-act/information-for-nawca-grantees/guidance-and-standards.php">Guidance &amp; Standards</a></li>
+              <li><a href="/birds/grants/north-american-wetland-conservation-act/information-for-nawca-grantees/forms.php">Forms</a></li>
+            </ul>
+          </li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/standard-grants.php">Standard Grants</a>
+            <ul>
+              <li><a href="/birds/grants/north-american-wetland-conservation-act/standard-grants/united-states.php">United States</a></li>
+              <li><a href="/birds/grants/north-american-wetland-conservation-act/standard-grants/canada.php">Canada</a></li>
+              <li><a href="/birds/grants/north-american-wetland-conservation-act/standard-grants/mexico.php">Mexico</a></li>
+            </ul>
+          </li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/nawca-project-summaries.php">NAWCA Project Summaries</a></li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/small-grants.php">Small Grants</a></li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/north-american-wetland-conservation-council.php">North American Wetlands Conservation Council</a></li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/biennial-reports.php">Biennial Reports</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act.php">Neotropical Migratory Bird Conservation Act</a>
+        <ul>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/how-to-apply.php">How to Apply</a></li>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/nmbca-project-summaries.php">NMBCA Project Summaries</a></li>
+         
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/information-for-nmbca-grantees.php">Information for NMBCA Grantees</a>
+            <ul>
+              <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/information-for-nmbca-grantees/managing-your-grant.php">Managing Your Grant</a></li>
+              <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/information-for-nmbca-grantees/annual-reporting-obligations.php">Annual Reporting Obligations</a></li>
+              <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/information-for-nmbca-grantees/grant-guidelines.php">Grant Guidelines</a></li>
+              <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/information-for-nmbca-grantees/faq.php">FAQ</a></li>
+            </ul>
+          </li>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/advisory-group.php">Advisory Group</a></li>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/nmbca-bird-list.php">NMBCA Bird List</a></li>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/communications-toolkit.php">Communications Toolkit</a></li>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/nmbca-espanol.php">En Español</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/grants/urban-bird-treaty.php">Urban Bird Treaty</a>
+        <ul>
+          <li><a href="/birds/grants/urban-bird-treaty/urban-bird-treaty-grant.php">Urban Bird Treaty Grant Information</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/grants/funding-sources-and-how-to-apply.php">Funding Sources &amp; How to Apply</a>
+      <ul>
+      <li><a href="/birds/grants/urban-bird-treaty/urban-bird-treaty-grant.php">Urban Bird Treaty Grant Information</a></li>
+      <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/webless-migratory-game-bird-program/request-for-proposals.php">Webless Migratory Game Bird Program</a></li>
+      </ul>
+      </li>
+      <li><a href="/birds/grants/payments.php">Payments</a></li>
+    </ul>
+  </li>
+  
+  <li><a href="/birds/education.php">Education</a>
+    <ul>
+      <li><a href="/birds/education/junior-duck-stamp-conservation-program.php">Junior Duck Stamp Conservation Program</a>
+        <ul>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/buy-junior-duck-stamps.php">Buy Junior Duck Stamps</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/conservation-education-curriculum.php">Conservation Education Curriculum</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/junior-duck-stamp-contest-information.php">Junior Duck Stamp Contest Information</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/junior-duck-stamp-in-your-state.php">Junior Duck Stamp in Your State</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/junior-duck-stamp-gallery.php">Junior Duck Stamp Gallery</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/junior-duck-stamp-art-tour.php">Junior Duck Stamp Art Exhibit Tour</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/education/education-resources.php">Education Resources</a>
+        <ul>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/youth-birding.php">Youth Birding</a></li>
+          <li><a href="/birds/education/education-resources/educators.php">Educators</a></li>
+          <li><a href="/birds/education/education-resources/parents.php">Parents</a></li>
+          <li><a href="/birds/education/education-resources/fact-sheets.php">Fact Sheets</a></li>
+          <li><a href="/birds/education/education-resources/multimedia.php">Multimedia</a></li>
+          <li><a href="/birds/education/education-resources/educational-activities.php">Activities</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/grants/urban-bird-treaty.php">Urban Birds</a></li>
+      <li><a href="/birds/education/international-migratory-bird-day.php">International Migratory Bird Day</a></li>
+    </ul>
+  </li>
+  
+  <li><a href="/birds/get-involved.php">Get Involved</a>
+    <ul>
+      <li><a href="/birds/get-involved/duck-stamp.php">Duck Stamp</a>
+        <ul>
+          <li><a href="/birds/get-involved/duck-stamp/history-of-the-federal-duck-stamp.php">History of the Federal Duck Stamp</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/buy-duck-stamp.php">Buy Duck Stamps</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/e-stamp.php">E-Stamp</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-dollars-at-work.php">Duck Stamp Dollars at Work</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-contest-and-event-information.php">Duck Stamp Contest &amp; Event Information</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-information-for-hunters.php">Duck Stamp Information for Hunters</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-information-for-birders-and-photographers.php">Duck Stamp Information for Birders &amp; Photographers</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-information-for-stamp-collectors.php">Duck Stamp Information for Stamp Collectors</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/sell-duck-stamp.php">Sell Duck Stamps</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/federal-duck-stamp-gallery.php">Federal Duck Stamp Gallery</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/federal-duck-stamp-art-exhibit-tour.php">Federal Duck Stamp Art Exhibit Tour</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-design-products-and-licensing-program.php">Duck Stamp Design Products &amp; Licensing Program</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program.php">Junior Duck Stamp Conservation Program</a>
+        </ul>
+      </li>
+      <li><a href="/birds/get-involved/invest-in-conservation.php">Invest in Conservation</a>
+        <ul>
+          <li><a href="/birds/get-involved/invest-in-conservation/donate.php">Donate</a></li>
+          <li><a href="/birds/get-involved/invest-in-conservation/provide-matching-funds.php">Provide Matching Funds</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/get-involved/citizen-science.php">Citizen Science</a></li>
+      <li><a href="/birds/get-involved/engaging-others.php">Engaging Others</a>
+        <ul>
+          <li><a href="/birds/get-involved/engaging-others/event.php">Special Event Tips & Examples</a></li>
+          <li><a href="/birds/get-involved/engaging-others/getting-publicity.php">Getting Publicity for Your Event</a></li>
+          <li><a href="/birds/get-involved/engaging-others/partnerships.php">Building Partnerships</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/about-us/strategicplan.php">Strategic Plan</a></li>
+    </ul>
+  </li>
+  
+  <li class="last submenus-left"><a href="/birds/policies-and-regulations.php">Policies &amp; Regulations</a>
+    <ul>
+      <li><a href="/birds/policies-and-regulations/laws-legislations.php">Laws/Legislation</a>
+        <ul>
+          <li><a href="/birds/policies-and-regulations/laws-legislations/migratory-bird-treaty-act.php">Migratory Bird Treaty Act</a></li>
+          <li><a href="/birds/policies-and-regulations/laws-legislations/migratory-bird-hunting-and-conservation-stamp-act.php">Migratory Bird Hunting &amp; Conservation Stamp Act</a></li>
+          <li><a href="/birds/policies-and-regulations/laws-legislations/bald-and-golden-eagle-protection-act.php">Bald &amp; Golden Eagle Protection Act</a></li>
+          <li><a href="/birds/policies-and-regulations/laws-legislations/other-relevant-laws.php">Other Relevant Laws</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/policies-and-regulations/policies.php">Policies</a></li>
+      <li><a href="/birds/policies-and-regulations/regulations.php">Regulations</a>
+        <ul>
+          <li><a href="/birds/policies-and-regulations/regulations/migratory-bird-hunting-regulations.php">Migratory Bird Hunting Regulations</a></li>
+          <li><a href="/birds/policies-and-regulations/regulations/national-environmental-policy-act.php">National Environmental Policy Act</a></li>
+          <li><a href="/birds/policies-and-regulations/regulations/how-regulations-are-set-the-process.php">How Regulations Are Set - The Process</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/policies-and-regulations/executive-orders.php">Executive Orders</a>
+        <ul>
+          <li><a href="/birds/policies-and-regulations/executive-orders/e0-13186.php">EO 13186</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/policies-and-regulations/federal-register-notices.php">Federal Register Notices</a></li>
+      <li><a href="/birds/policies-and-regulations/permits.php">Permits</a>
+        <ul>
+          <li><a href="/birds/policies-and-regulations/permits/regional-permit-contacts.php">Regional Permit Contacts</a></li>
+          <li><a href="/birds/policies-and-regulations/permits/permit-policies-and-regulations.php">Permit Policies &amp; Regulations</a></li>
+          <li><a href="/birds/policies-and-regulations/permits/need-a-permit.php">Need a Permit</a></li>
+        </ul>
+      </li>
+    <li><a href="/birds/policies-and-regulations/incidental-take.php">Incidental Take</a></ul>
+  </li>  
+</ul>			</nav>
+			<div id="expand-button"><a href="#"><span class="expand"><i class="fa fa-plus"></i> Expand</span> <span class="minimize"><i class="fa fa-minus"></i> Minimize</span></a></div>
+		</div>
+	</div>
+		
+	<div id="subfooter">
+		<div class="wrap">
+			<nav>
+<ul>
+	<li><a href="/birds/index.php">Home</a></li>
+	<li><a href="https://www.fws.gov/">U.S. Fish And Wildlife Service Home</a></li>
+	<li><a href="http://www.doi.gov/" title="Link to non-FWS site">Department Of The Interior</a></li>
+	<li><a href="http://www.usa.gov/" title="Link to non-FWS site">USA.gov</a></li>
+	<li><a href="https://www.fws.gov/help/about_us.html">About The Fish And Wildlife Service</a></li>
+	<li><a href="https://www.fws.gov/help/accessibility.html">Accessibility</a></li>
+	<li><a href="https://www.fws.gov/help/policies.html">Privacy</a></li>
+	<li><a href="https://www.fws.gov/help/notices.html">Notices</a></li>
+	<li><a href="https://www.fws.gov/help/disclaimer.html">Disclaimer</a></li>
+	<li><a href="https://www.fws.gov/irm/bpim/foia.html">FOIA</a></li>
+</ul>			</nav>
+		</div>
+	</div>
+
+</footer><nav id="mobile-menu"><ul>
+	<li class="first"><a href="/birds/bird-enthusiasts.php">Bird Enthusiasts</a>
+    <ul>
+      <li><a href="/birds/bird-enthusiasts/bird-watching.php">Bird Watching</a>
+        <ul>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/bird-identification.php">Bird Identification</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification.php">Waterfowl Identification</a>
+          	<ul>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/american-black-duck.php">American Black Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/american-wigeon.php">Aerican Wigeon</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/barrows-goldeneye.php">Barrows Goldeneye</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/black-scoter.php">Black Scoter</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/blue-winged-teal.php">Blue-winged Teal</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/brant.php">Brant</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/bufflehead.php">Bufflehead</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/canada-goose.php">Canada Goose</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/canvasback.php">Canvasback</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/cinnamon-teal.php">Cinnamon Teal</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/common-eider.php">Common Eider</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/common-goldeneye.php">Common Goldeneye</a></li>
+        	  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/common-merganser.php">Common Merganser</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/gadwall.php">Gadwall</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/greater-scaup.php">Greater Scaup</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/green-winged-teal.php">Green-winged Teal</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/harlequin-duck.php">Harlequin Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/hooded-merganser.php">Hooded Merganser</a></li>
+        	  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/king-eider.php">King Eider</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/lesser-scaup.php">Lesser Scaup</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/long-tailed-duck.php">Long-tailed Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/mallard.php">Mallard</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/mottled-duck.php">Mottled Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/northern-pintail.php">Northern Pintail</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/northern-shoveler.php">Northern Shoveler</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/red-breasted-merganser.php">Red-breasted Merganser</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/redhead.php">Redhead</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/ring-necked-duck.php">Ring-necked Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/ruddy-duck.php">Ruddy Duck</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/snow-goose.php">Snow Goose</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/surf-scoter.php">Surf Scoter</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/trumpeter-swan.php">Trumpeter Swan</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/tundra-swan.php">Tundra Swan</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/whistling-duck.php">Whistling Duck</a></li>
+        	  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/white-fronted-goose.php">White-fronted Goose</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/white-winged-scoter.php">White-winged Scoter</a></li>
+			  <li><a href="/birds/bird-enthusiasts/bird-watching/waterfowl-identification/wood-duck.php">Wood Duck</a></li>
+			</ul>
+         </li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/finding-birds.php">Finding Birds</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/festivals-and-events.php">Festivals &amp; Events</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/birdwalk.php">Bird Walks</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/youth-birding.php">Youth Birding</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/bird-watching-tools.php">Bird Watching Tools</a></li>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/valuing-birds.php">Economic Impact</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/bird-enthusiasts/hunting.php">Hunting</a></li>
+      <li><a href="/birds/bird-enthusiasts/backyard.php">Backyard Birding</a></li>
+      <li><a href="/birds/bird-enthusiasts/threats-to-birds.php">Threats to Birds</a>
+        <ul>
+          <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions.php">Collisions</a>
+            <ul>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/buildings-and-glass.php">Buildings &amp; Glass</a></li>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/road-vehicles.php">Road Vehicles</a></li>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/aircrafts.php">Aircraft</a></li>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/electric-utility-lines.php">Electric Utility Lines</a></li>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/communication-towers.php">Communication Towers</a></li>
+              <li><a href="/birds/bird-enthusiasts/threats-to-birds/collisions/wind-turbines.php">Wind Turbines</a></li>
+            </ul>
+          </li>
+<li><a href="/birds/bird-enthusiasts/threats-to-birds/disease.php">Disease</a></li>
+          <li><a href="/birds/bird-enthusiasts/threats-to-birds/entrapment-entanglement-drowning.php">Entrapment, Entanglement &amp; Drowning</a></li>
+          <li><a href="/birds/bird-enthusiasts/threats-to-birds/electrocutions.php">Electrocutions</a></li>
+          <li><a href="/birds/bird-enthusiasts/threats-to-birds/habitat-impacts.php">Habitat Impacts</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/faqs.php">FAQs/Commonly Asked Questions</a></li>
+      <li><a href="/birds/about-us/timeline.php">Bird Conservation Timeline</a></li>
+    </ul>
+  </li>
+  
+  <li><a href="/birds/surveys-and-data.php">Surveys &amp; Data</a>
+    <ul>
+      <li><a href="/birds/surveys-and-data/population-surveys.php">Population Surveys</a>
+        <ul>
+          <li><a href="/birds/surveys-and-data/population-surveys/aerial-ground-crew-blog.php">Aerial &amp; Ground Crew Blog</a></li>
+        </ul>
+        </li>
+      <li><a href="/birds/surveys-and-data/bird-banding.php">Bird Banding</a>
+        <ul>
+          <li><a href="/birds/surveys-and-data/bird-banding/reporting-banded-birds.php">Reporting Banded Birds</a></li>
+          <li><a href="/birds/surveys-and-data/bird-banding/reward-bands.php">Reward Bands</a></li>
+          <li><a href="/birds/surveys-and-data/bird-banding/waterfowl-banding-blog.php">Waterfowl Banding Blog</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/surveys-and-data/harvest-surveys.php">Harvest Surveys</a>
+        <ul>
+          <li><a href="/birds/surveys-and-data/harvest-surveys/harvest-information-program.php">Harvest Information Program</a></li>
+          <li><a href="/birds/surveys-and-data/harvest-surveys/diary-surveys.php">Diary Surveys</a></li>
+          <li><a href="/birds/surveys-and-data/harvest-surveys/parts-collection-surveys.php">Parts Collection Surveys</a>          </li>
+              <li><a href="/birds/surveys-and-data/harvest-surveys/bird-and-wing-id.php">Bird &amp; Wing ID</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/surveys-and-data/webless-migratory-game-birds.php">Webless Migratory Game Birds</a>
+        <ul>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/webless-migratory-game-bird-program.php">Webless Migratory Game Bird Program</a>
+            <ul>
+              <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/webless-migratory-game-bird-program/request-for-proposals.php">Request for Proposals</a></li>
+              <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/webless-migratory-game-bird-program/project-abstracts.php">Project Abstracts</a></li>
+            </ul>
+          </li>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/priority-information-needs.php">Priority Information Needs</a></li>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/american-woodcock.php">American Woodcock</a></li>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/doves-and-pigeons.php">Doves &amp; Pigeons</a></li>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/sandhill-cranes.php">Sandhill Cranes</a></li>
+          <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/marshbirds.php">Marshbirds</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/surveys-and-data/migratory-bird-data-center.php">Migratory Bird Data Center</a></li>
+      <li><a href="/birds/surveys-and-data/aviation.php">Aviation</a></li>
+      <li><a href="/birds/surveys-and-data/reports-and-publications.php">Reports &amp; Publications</a>
+        <ul>
+          <li><a href="/birds/surveys-and-data/reports-and-publications/population-status.php">Population Status</a></li>
+          <li><a href="/birds/surveys-and-data/reports-and-publications/hunting-activity-and-harvest.php">Hunting Activity &amp; Harvest</a></li>
+          <li><a href="/birds/surveys-and-data/reports-and-publications/flyway-data-books.php">Flyway Data Books</a></li>
+          <li><a href="/birds/management/adaptive-harvest-management/publications-and-reports.php">Adaptive Harvest Management Report</a>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  
+  <li><a href="/birds/management.php">Management</a>
+    <ul>
+      <li><a href="/birds/management/managed-species.php">Managed Species</a>
+        <ul>
+          <li><a href="/birds/management/managed-species/bald-and-golden-eagle-information.php">Bald &amp; Golden Eagle Information</a>
+          <ul>
+          <li><a href="/birds/management/managed-species/eagle-management.php">Eagle Management</a></li>
+          </ul>
+          <li><a href="/birds/management/managed-species/migratory-bird-treaty-act-protected-species.php">Migratory Bird Treaty Act Protected Species (10.13 List)</a></li>
+              <li><a href="/birds/management/managed-species/birds-of-conservation-concern.php">Birds of Conservation Concern</a></li>
+              <li><a href="/birds/management/managed-species/focal-species.php">Focal Species</a></li>
+              <li><a href="/birds/management/managed-species/birds-of-management-concern.php">Birds of Management Concern</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/bird-enthusiasts/threats-to-birds.php">Managing Threats to Birds</a></li>
+      <li><a href="/birds/policies-and-regulations/incidental-take.php">Managing Incidental Take</a>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance.php">Project Assessment Tools &amp; Guidance</a>
+        <ul>
+          <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents.php">Guidance Documents</a>
+            <ul>
+              <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/communication-towers.php">Communication Tower</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/electric-utility-lines.php">Electric Utility Line</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/oil-and-gas.php">Oil &amp; Gas</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/wind-energy.php">Wind Energy</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/eagles.php">Eagles</a></li>
+            </ul>
+          </li>
+          <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures.php">Conservation Measures</a>
+          <ul>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/nationwide-standard-conservation-measures.php">Nationwide Conservation Measures</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/building-glass-and-lighting.php">Buildings, Glass &amp; Lighting</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/communication-towers.php">Communication Towers</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/coal-bed-methane.php">Coal-bed Methane</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/hunting-and-fishing.php">Hunting &amp; Fishing</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/electric-utility.php">Electric Utility</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/fluid-minerals.php">Fluid Mineral Practices</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/mining-claim-markers.php">Mining Claim Markers</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/outdoor-lighting.php">Outdoor Lighting</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/transportation.php">Transportation</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/vegetation-management.php">Vegetation Management</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/wind-energy.php">Wind Energy</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/guidance-documents/eagles.php">Eagles</a></li>
+             <li><a href="/birds/management/project-assessment-tools-and-guidance/conservation-measures/sage-grouse.php">Sage-Grouse</a></li>
+            </ul>
+            </li>
+          <li><a href="/birds/management/project-assessment-tools-and-guidance/decision-support-tools.php">Decision Support Tools</a>
+          <ul>
+              <li><a href="/birds/management/project-assessment-tools-and-guidance/decision-support-tools/akn-histogram-tools.php">Avian Knowledge Network Histogram Tools</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/decision-support-tools/imr.php">Injury and Mortality Reporting System</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/decision-support-tools/ipac.php">Information for Planning and Conservation System</a></li>
+      <li><a href="/birds/management/project-assessment-tools-and-guidance/decision-support-tools/bird-data-and-information.php">Other Bird Data and Information Resources</a></li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li><a href="/birds/management/adaptive-harvest-management.php">Adaptive Harvest Management</a>
+        <ul>
+          <li><a href="/birds/management/adaptive-harvest-management/publications-and-reports.php">Publications &amp; Reports</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/management/flyways.php">Flyways</a></li>
+      <li><a href="/birds/management/bird-management-plans.php">Bird Management Plans</a>
+        <ul>
+          <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan.php">North American Waterfowl Management Plan</a>
+           <ul>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/integrating-waterfowl-management.php">Integrating Waterfowl Management</a></li>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/plan-committee.php">Plan Committee</a></li>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/working-groups-and-subcommittees.php">Working Groups &amp; Subcommittees</a></li>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/plan-documents.php">Plan Documents</a></li>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/plan-awards.php">Plan Awards</a></li>
+              <li><a href="/birds/management/bird-management-plans/north-american-waterfowl-management-plan/nawmp-science-support-team.php">NAWMP Science Support Team</a></li>
+            </ul>
+            </li>
+          <li><a href="/birds/management/bird-management-plans/partners-in-flight-north-american-landbird-conservation-plan.php">Partners in Flight North American Landbird Conservation Plan</a></li>
+          <li><a href="/birds/management/bird-management-plans/waterbird-conservation-for-the-americas.php">Waterbird Conservation for the Americas</a></li>
+          <li><a href="/birds/management/bird-management-plans/the-us-shorebird-conservation-plan.php">The U.S. Shorebird Conservation Plan</a></li>
+          <li><a href="/birds/management/managed-species/focal-species.php">Focal Species Plans</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/management/bird-conservation-partnership-and-initiatives.php">Bird Conservation Partnerships &amp; Initiatives</a>
+        <ul>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds.php">Council for the Conservation of Migratory Birds</a>
+            <ul>
+                        <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds/participating-council-agencies.php">Participating Council Agencies</a></li>
+                        <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds/partnership-agreements.php">Partnership Agreements</a></li>
+                        <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds/council-annual-reports.php">Council Annual Reports</a></li>
+                        <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds/presidential-award.php">Presidential Award</a></li>
+                        <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/council-for-the-conservation-of-migratory-birds/council-newsletter.php">Council Newsletter</a></li>
+                    
+            </ul>
+          </li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/migratory-bird-joint-ventures.php">Migratory Bird Joint Ventures</a>
+          <ul>
+              <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/migratory-bird-joint-ventures/joint-venture-directory.php">Joint Venture Directory</a></li>
+              <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/migratory-bird-joint-ventures/map-products.php">Map Products</a></li>
+              <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/migratory-bird-joint-ventures/policy.php">Policy</a></li>
+            </ul>
+          </li>
+            <li><a href="/birds/management/flyways.php">Migratory Bird Flyways</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/north-american-bird-conservation-initiative.php">North American Bird Conservation Initiative</a></li>
+          <li><a href="/birds/grants/urban-bird-treaty.php">Urban Bird Treaty Program</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/shorebird-conservation.php">Shorebird Conservation</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/waterbird-conservation.php">Waterbird Conservation</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/partners-in-flight.php">Partners in Flight</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/waterfowl-conservation.php">Waterfowl Conservation</a></li>
+          <li><a href="/birds/about-us/International.php">International Cooperation</a></li>
+          <li><a href="/birds/management/bird-conservation-partnership-and-initiatives/partners.php">Other Partners</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/management/training.php">Training</a>
+        <ul>
+          <li><a href="/birds/management/training/migratory-bird-conservation-a-trust-responsibility.php">Migratory Bird Conservation: A Trust Responsibility</a></li>
+          <li><a href="/birds/management/training/migratory-bird-conservation-for-federal-partners.php">Migratory Bird Conservation for Federal Partners</a></li>
+          <li><a href="/birds/management/training/basic-bird-biology.php">Basic Bird Biology</a></li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  
+  <li><a href="/birds/grants.php">Grants</a>
+    <ul>
+      <li><a href="/birds/grants/north-american-wetland-conservation-act.php">North American Wetlands Conservation Act</a>
+        <ul>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/how-to-apply-for-a-nawca-grant.php">How to Apply for a NAWCA Grant</a></li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/information-for-nawca-grantees.php">Information for NAWCA Grantees</a>
+            <ul>
+              <li><a href="/birds/grants/north-american-wetland-conservation-act/information-for-nawca-grantees/guidance-and-standards.php">Guidance &amp; Standards</a></li>
+              <li><a href="/birds/grants/north-american-wetland-conservation-act/information-for-nawca-grantees/forms.php">Forms</a></li>
+            </ul>
+          </li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/standard-grants.php">Standard Grants</a>
+            <ul>
+              <li><a href="/birds/grants/north-american-wetland-conservation-act/standard-grants/united-states.php">United States</a></li>
+              <li><a href="/birds/grants/north-american-wetland-conservation-act/standard-grants/canada.php">Canada</a></li>
+              <li><a href="/birds/grants/north-american-wetland-conservation-act/standard-grants/mexico.php">Mexico</a></li>
+            </ul>
+          </li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/nawca-project-summaries.php">NAWCA Project Summaries</a></li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/small-grants.php">Small Grants</a></li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/north-american-wetland-conservation-council.php">North American Wetlands Conservation Council</a></li>
+          <li><a href="/birds/grants/north-american-wetland-conservation-act/biennial-reports.php">Biennial Reports</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act.php">Neotropical Migratory Bird Conservation Act</a>
+        <ul>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/how-to-apply.php">How to Apply</a></li>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/nmbca-project-summaries.php">NMBCA Project Summaries</a></li>
+         
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/information-for-nmbca-grantees.php">Information for NMBCA Grantees</a>
+            <ul>
+              <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/information-for-nmbca-grantees/managing-your-grant.php">Managing Your Grant</a></li>
+              <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/information-for-nmbca-grantees/annual-reporting-obligations.php">Annual Reporting Obligations</a></li>
+              <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/information-for-nmbca-grantees/grant-guidelines.php">Grant Guidelines</a></li>
+              <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/information-for-nmbca-grantees/faq.php">FAQ</a></li>
+            </ul>
+          </li>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/advisory-group.php">Advisory Group</a></li>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/nmbca-bird-list.php">NMBCA Bird List</a></li>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/communications-toolkit.php">Communications Toolkit</a></li>
+          <li><a href="/birds/grants/neotropical-migratory-bird-conservation-act/nmbca-espanol.php">En Español</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/grants/urban-bird-treaty.php">Urban Bird Treaty</a>
+        <ul>
+          <li><a href="/birds/grants/urban-bird-treaty/urban-bird-treaty-grant.php">Urban Bird Treaty Grant Information</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/grants/funding-sources-and-how-to-apply.php">Funding Sources &amp; How to Apply</a>
+      <ul>
+      <li><a href="/birds/grants/urban-bird-treaty/urban-bird-treaty-grant.php">Urban Bird Treaty Grant Information</a></li>
+      <li><a href="/birds/surveys-and-data/webless-migratory-game-birds/webless-migratory-game-bird-program/request-for-proposals.php">Webless Migratory Game Bird Program</a></li>
+      </ul>
+      </li>
+      <li><a href="/birds/grants/payments.php">Payments</a></li>
+    </ul>
+  </li>
+  
+  <li><a href="/birds/education.php">Education</a>
+    <ul>
+      <li><a href="/birds/education/junior-duck-stamp-conservation-program.php">Junior Duck Stamp Conservation Program</a>
+        <ul>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/buy-junior-duck-stamps.php">Buy Junior Duck Stamps</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/conservation-education-curriculum.php">Conservation Education Curriculum</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/junior-duck-stamp-contest-information.php">Junior Duck Stamp Contest Information</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/junior-duck-stamp-in-your-state.php">Junior Duck Stamp in Your State</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/junior-duck-stamp-gallery.php">Junior Duck Stamp Gallery</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program/junior-duck-stamp-art-tour.php">Junior Duck Stamp Art Exhibit Tour</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/education/education-resources.php">Education Resources</a>
+        <ul>
+          <li><a href="/birds/bird-enthusiasts/bird-watching/youth-birding.php">Youth Birding</a></li>
+          <li><a href="/birds/education/education-resources/educators.php">Educators</a></li>
+          <li><a href="/birds/education/education-resources/parents.php">Parents</a></li>
+          <li><a href="/birds/education/education-resources/fact-sheets.php">Fact Sheets</a></li>
+          <li><a href="/birds/education/education-resources/multimedia.php">Multimedia</a></li>
+          <li><a href="/birds/education/education-resources/educational-activities.php">Activities</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/grants/urban-bird-treaty.php">Urban Birds</a></li>
+      <li><a href="/birds/education/international-migratory-bird-day.php">International Migratory Bird Day</a></li>
+    </ul>
+  </li>
+  
+  <li><a href="/birds/get-involved.php">Get Involved</a>
+    <ul>
+      <li><a href="/birds/get-involved/duck-stamp.php">Duck Stamp</a>
+        <ul>
+          <li><a href="/birds/get-involved/duck-stamp/history-of-the-federal-duck-stamp.php">History of the Federal Duck Stamp</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/buy-duck-stamp.php">Buy Duck Stamps</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/e-stamp.php">E-Stamp</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-dollars-at-work.php">Duck Stamp Dollars at Work</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-contest-and-event-information.php">Duck Stamp Contest &amp; Event Information</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-information-for-hunters.php">Duck Stamp Information for Hunters</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-information-for-birders-and-photographers.php">Duck Stamp Information for Birders &amp; Photographers</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-information-for-stamp-collectors.php">Duck Stamp Information for Stamp Collectors</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/sell-duck-stamp.php">Sell Duck Stamps</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/federal-duck-stamp-gallery.php">Federal Duck Stamp Gallery</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/federal-duck-stamp-art-exhibit-tour.php">Federal Duck Stamp Art Exhibit Tour</a></li>
+          <li><a href="/birds/get-involved/duck-stamp/duck-stamp-design-products-and-licensing-program.php">Duck Stamp Design Products &amp; Licensing Program</a></li>
+          <li><a href="/birds/education/junior-duck-stamp-conservation-program.php">Junior Duck Stamp Conservation Program</a>
+        </ul>
+      </li>
+      <li><a href="/birds/get-involved/invest-in-conservation.php">Invest in Conservation</a>
+        <ul>
+          <li><a href="/birds/get-involved/invest-in-conservation/donate.php">Donate</a></li>
+          <li><a href="/birds/get-involved/invest-in-conservation/provide-matching-funds.php">Provide Matching Funds</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/get-involved/citizen-science.php">Citizen Science</a></li>
+      <li><a href="/birds/get-involved/engaging-others.php">Engaging Others</a>
+        <ul>
+          <li><a href="/birds/get-involved/engaging-others/event.php">Special Event Tips & Examples</a></li>
+          <li><a href="/birds/get-involved/engaging-others/getting-publicity.php">Getting Publicity for Your Event</a></li>
+          <li><a href="/birds/get-involved/engaging-others/partnerships.php">Building Partnerships</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/about-us/strategicplan.php">Strategic Plan</a></li>
+    </ul>
+  </li>
+  
+  <li class="last submenus-left"><a href="/birds/policies-and-regulations.php">Policies &amp; Regulations</a>
+    <ul>
+      <li><a href="/birds/policies-and-regulations/laws-legislations.php">Laws/Legislation</a>
+        <ul>
+          <li><a href="/birds/policies-and-regulations/laws-legislations/migratory-bird-treaty-act.php">Migratory Bird Treaty Act</a></li>
+          <li><a href="/birds/policies-and-regulations/laws-legislations/migratory-bird-hunting-and-conservation-stamp-act.php">Migratory Bird Hunting &amp; Conservation Stamp Act</a></li>
+          <li><a href="/birds/policies-and-regulations/laws-legislations/bald-and-golden-eagle-protection-act.php">Bald &amp; Golden Eagle Protection Act</a></li>
+          <li><a href="/birds/policies-and-regulations/laws-legislations/other-relevant-laws.php">Other Relevant Laws</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/policies-and-regulations/policies.php">Policies</a></li>
+      <li><a href="/birds/policies-and-regulations/regulations.php">Regulations</a>
+        <ul>
+          <li><a href="/birds/policies-and-regulations/regulations/migratory-bird-hunting-regulations.php">Migratory Bird Hunting Regulations</a></li>
+          <li><a href="/birds/policies-and-regulations/regulations/national-environmental-policy-act.php">National Environmental Policy Act</a></li>
+          <li><a href="/birds/policies-and-regulations/regulations/how-regulations-are-set-the-process.php">How Regulations Are Set - The Process</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/policies-and-regulations/executive-orders.php">Executive Orders</a>
+        <ul>
+          <li><a href="/birds/policies-and-regulations/executive-orders/e0-13186.php">EO 13186</a></li>
+        </ul>
+      </li>
+      <li><a href="/birds/policies-and-regulations/federal-register-notices.php">Federal Register Notices</a></li>
+      <li><a href="/birds/policies-and-regulations/permits.php">Permits</a>
+        <ul>
+          <li><a href="/birds/policies-and-regulations/permits/regional-permit-contacts.php">Regional Permit Contacts</a></li>
+          <li><a href="/birds/policies-and-regulations/permits/permit-policies-and-regulations.php">Permit Policies &amp; Regulations</a></li>
+          <li><a href="/birds/policies-and-regulations/permits/need-a-permit.php">Need a Permit</a></li>
+        </ul>
+      </li>
+    <li><a href="/birds/policies-and-regulations/incidental-take.php">Incidental Take</a></ul>
+  </li>  
+</ul></nav>
+</div>
+
+<!--jquery-->
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script> 
+<script>window.jQuery || document.write('<script src="/birdhabitat/js/vendor/jquery-1.10.1.min.js"><\/script>')</script> 
+
+<!--mobile menu-->
+<script type="text/javascript" src="/birdhabitat/js/jquery.mmenu.js"></script>
+
+<!--responsive images-->
+<!--Picturefill-->
+<script src="/birdhabitat/js/picturefill/matchmedia.js"></script>
+<script src="/birdhabitat/js/picturefill/picturefill.js"></script>
+
+<!--custom scripts-->
+<script src="/birdhabitat/js/main.js"></script> 
+
+
+<!--MM_jumpMenu-->
+<script type='text/javascript' src='/birdhabitat/files/reloadJumpmenu.js'></script>
+
+<!--Google Analytics-->
+<script>
+	var _gaq = _gaq || [];
+_gaq.push(['_setAccount', 'UA-24008743-1']);
+_gaq.push(['_trackPageview']);
+
+(function() {
+var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+})();
+</script>
+
+<!--expandable faq custom scripts-->
+<script type="text/javascript" src="//code.jquery.com/jquery-1.11.0.min.js"></script>
+
+<script>
+ $(document).ready(function() {
+ 
+    $('.faq_question').click(function() {
+ 
+        if ($(this).parent().is('.open')){
+            $(this).closest('.faq').find('.faq_answer_container').animate({'height':'0'},500);
+            $(this).closest('.faq').removeClass('open');
+ 
+            }else{
+                var newHeight =$(this).closest('.faq').find('.faq_answer').height() +'px';
+                $(this).closest('.faq').find('.faq_answer_container').animate({'height':newHeight},500);
+                $(this).closest('.faq').addClass('open');
+            }
+ 
+    });
+ 
+});
+</script>
+
+
+<!--ncshare scripts-->
+<script type="text/javascript" src="/birdhabitat/js/ncshare/ncshare.min.js"></script>
+
+
+<script>
+function openTab(evt, tabName) {
+    var i, tabcontent, tablinks;
+	tabcontent = document.getElementsByClassName("tabcontent");
+    for (i = 0; i < tabcontent.length; i++) {
+        tabcontent[i].style.display = "none";
+    }
+	tablinks = document.getElementsByClassName("tablinks");
+    for (i = 0; i < tablinks.length; i++) {
+        tablinks[i].className = tablinks[i].className.replace(" active", "");
+    }
+	document.getElementById(tabName).style.display = "block";
+    evt.currentTarget.className += " active";
+}
+	document.getElementById("defaultOpen").click();
+</script>
+<!-- InstanceBeginEditable name="content-footer" -->
+<!--bottom include: used for scripts, footers, etc-->
+<!-- InstanceEndEditable -->
+</body>
+<!-- InstanceEnd --></html>

--- a/wayback/tests/test_utils.py
+++ b/wayback/tests/test_utils.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timezone
+import pytest
+from .._utils import memento_url_data
+
+
+class TestMementoUrlData:
+    def test_extracts_url(self):
+        url, timestamp, mode = memento_url_data(
+            'http://web.archive.org/web/20170813195036/'
+            'https://arpa-e.energy.gov/?q=engage/events-workshops')
+        assert url == 'https://arpa-e.energy.gov/?q=engage/events-workshops'
+        assert timestamp == datetime(2017, 8, 13, 19, 50, 36, tzinfo=timezone.utc)
+        assert mode == ''
+
+        url, timestamp, mode = memento_url_data(
+            'http://web.archive.org/web/20170813195036id_/'
+            'https://arpa-e.energy.gov/?q=engage/events-workshops')
+        assert url == 'https://arpa-e.energy.gov/?q=engage/events-workshops'
+        assert timestamp == datetime(2017, 8, 13, 19, 50, 36, tzinfo=timezone.utc)
+        assert mode == 'id_'
+
+    def test_decodes_url(self):
+        url, _, _ = memento_url_data(
+            'http://web.archive.org/web/20150930233055id_/'
+            'http%3A%2F%2Fwww.epa.gov%2Fenvironmentaljustice%2Fgrants%2Fej-smgrants.html%3Futm')
+        assert url == 'http://www.epa.gov/environmentaljustice/grants/ej-smgrants.html?utm'
+
+    def test_does_not_decode_query(self):
+        url, _, _ = memento_url_data(
+            'http://web.archive.org/web/20170813195036/'
+            'https://arpa-e.energy.gov/?q=engage%2Fevents-workshops')
+        assert url == 'https://arpa-e.energy.gov/?q=engage%2Fevents-workshops'
+
+    def test_raises_for_non_memento_urls(self):
+        with pytest.raises(ValueError):
+            memento_url_data('http://whatever.com')
+
+    def test_raises_for_non_string_input(self):
+        with pytest.raises(TypeError):
+            memento_url_data(None)


### PR DESCRIPTION
Rather than returning a requests.Response object from `WaybackClient.get_memento()`, we now return a completely new `Memento` type. It’s similar to requests.Response in a lot of ways, but it contains additional properties that are specific to mementos (like a timestamp) and has different values that reflect the historical archive rather than the exact response the Wayback Machine sent (e.g. `url` is the URL of the archived page, not `http://web.archive.org/web/<date>/<url>`; `headers` contains only the historic headers, not additional info added by the Wayback Machine).

There are two major reasons for this:

1. We can provide some more useful conveniences like the above noted bits.

2. We can change the underlying HTTP implementation, since we no longer expose it publicly. This is critical to getting thread safety, since Requests is not thread safe and it doesn’t look like that’s going to change soon or really ever be something they want to guarantee. Actually swapping out the underlying HTTP library is not intended to be part of this PR, though. That’ll be done separately.

    (It’ll be sad to lose some of Requests’s conveniences, but we aren’t making general purpose HTTP calls, so many of them aren’t as necessary to us — we have a lot more constraints around our usage.)

Note this drops a few features from #2 that I ultimately decided were a bit too complex (e.g. detailed media type parsing) and/or non-critical (e.g. parsing out all the timemap info from the `Links` header). We can add those in later.

**To-do:**

- [x] Code reorganization. I kinda feel like there was already too much in `_client.py` and this really pushes it well beyond.
- [x] Decide on `Memento.timestamp` vs. `Memento.datetime`.
- [x] Validate this API against scripts in web-monitoring-processing to make sure we aren’t leaving any majorly helpful features out or making anything too complicated.