### PR TITLE
Fix `target_window` when redirect is > 1 day

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -5,7 +5,7 @@ Release History
 v0.2.5 (2020-10-19)
 -------------------
 
-This release fixes a bug where the ``target_window`` parameter for :meth:`wayback.WaybackClient.get_memento` did not work correctly if the memento you were redirected to was off by more than a day. See `#53 <https://github.com/edgi-govdata-archiving/wayback/pull/53>`_ for more.
+This release fixes a bug where the ``target_window`` parameter for :meth:`wayback.WaybackClient.get_memento` did not work correctly if the memento you were redirected to was off by more than a day from the reequested time. See `#53 <https://github.com/edgi-govdata-archiving/wayback/pull/53>`_ for more.
 
 
 v0.2.4 (2020-09-07)

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -2,6 +2,12 @@
 Release History
 ===============
 
+v0.2.5 (2020-10-19)
+-------------------
+
+This release fixes a bug where the ``target_window`` parameter for :meth:`wayback.WaybackClient.get_memento` did not work correctly if the memento you were redirected to was off by more than a day. See `#53 <https://github.com/edgi-govdata-archiving/wayback/pull/53>`_ for more.
+
+
 v0.2.4 (2020-09-07)
 -------------------
 

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -748,7 +748,7 @@ class WaybackClient(_utils.DepthCountedContext):
                         # been produced by an earlier memento redirect -- it's
                         # just the *closest* one. The first job here is to make
                         # sure it fits within our target window.
-                        if abs(target_date - original_date).seconds <= target_window:
+                        if abs(target_date - original_date).total_seconds() <= target_window:
                             # The redirect will point to the closest-in-time
                             # SURT URL, which will often not be an exact URL
                             # match. If we aren't looking for exact matches,

--- a/wayback/tests/cassettes/test_get_memento_raises_when_memento_is_outside_target_window
+++ b/wayback/tests/cassettes/test_get_memento_raises_when_memento_is_outside_target_window
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - wayback/0.2.4.post2.dev0+g0c2a63c (+https://github.com/edgi-govdata-archiving/wayback)
+    method: GET
+    uri: http://web.archive.org/web/20171101000000id_/https://www.fws.gov/birds/
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Mon, 19 Oct 2020 08:07:14 GMT
+      Location:
+      - http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+      Server:
+      - nginx/1.15.8
+      Server-Timing:
+      - RedisCDXSource;dur=220.587665, PetaboxLoader3.resolve;dur=21.099726, exclusion.robots.policy;dur=0.321841,
+        CDXLines.iter;dur=21.136237, LoadShardBlock;dur=1556.284805, captures_list;dur=1886.300549,
+        PetaboxLoader3.datanode;dur=119.223321, esindex;dur=0.009743, exclusion.robots;dur=0.338801
+      X-App-Server:
+      - wwwb-app13
+      X-Archive-Redirect-Reason:
+      - found capture at 20171124151315
+      X-Archive-Screenname:
+      - '0'
+      X-Cache-Key:
+      - httpweb.archive.org/web/20171101000000id_/https://www.fws.gov/birds/US
+      X-Page-Cache:
+      - HIT
+      X-location:
+      - All
+      X-ts:
+      - '302'
+    status:
+      code: 302
+      message: FOUND
+version: 1

--- a/wayback/tests/cassettes/test_get_memento_target_window
+++ b/wayback/tests/cassettes/test_get_memento_target_window
@@ -1,0 +1,546 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - wayback/0.2.4.post2.dev0+g0c2a63c (+https://github.com/edgi-govdata-archiving/wayback)
+    method: GET
+    uri: http://web.archive.org/web/20171101000000id_/https://www.fws.gov/birds/
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Mon, 19 Oct 2020 08:07:13 GMT
+      Location:
+      - http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+      Server:
+      - nginx/1.15.8
+      Server-Timing:
+      - RedisCDXSource;dur=220.587665, PetaboxLoader3.resolve;dur=21.099726, exclusion.robots.policy;dur=0.321841,
+        CDXLines.iter;dur=21.136237, LoadShardBlock;dur=1556.284805, captures_list;dur=1886.300549,
+        PetaboxLoader3.datanode;dur=119.223321, esindex;dur=0.009743, exclusion.robots;dur=0.338801
+      X-App-Server:
+      - wwwb-app13
+      X-Archive-Redirect-Reason:
+      - found capture at 20171124151315
+      X-Archive-Screenname:
+      - '0'
+      X-Cache-Key:
+      - httpweb.archive.org/web/20171101000000id_/https://www.fws.gov/birds/US
+      X-Page-Cache:
+      - MISS
+      X-location:
+      - All
+      X-ts:
+      - '302'
+    status:
+      code: 302
+      message: FOUND
+- request:
+    body: null
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - wayback/0.2.4.post2.dev0+g0c2a63c (+https://github.com/edgi-govdata-archiving/wayback)
+    method: GET
+    uri: http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2975LbyJEv+nn0FGV6Y6UJCw21NPaMZ6Te038ljdWjtrplHYevw4EmQRJqkqAJ
+        sKm21xHn+32afYZ9k/sk55eZVYUCUCRBNtEzG3Endq1GAazMysrKzMrMynr5q5P3x1d/vjhVw3w8
+        Onj08ldB8Jekr0a5enuqvv3rgeL/XtJb1R1FWfaqM0mDzxm+CJL49/LPd/LPt50D9fJXf4knvaT/
+        1yAoenO7Qn/relvRzXcGo1XdLPv9gAeFLmiUwK42qA6/UW8nWR5NuvFRPEgmKo/H01GUx6864ZX+
+        MwuH6Tje6y3yvelw2lHdtBe/n+dZ0ovfXJ2/e5u9S7s3ce9Vpx+NsrijDC3KxBnGUU9oVIZ42kvy
+        6HoUq0k0BtRe2s2TfGS64b8PPu5d7qmzJBuqf4/G0x/Up2TUGyX9WF3Gs9ukG6tAnSeDWZSnszt1
+        lMx66mKW4nms/lMdp5OMvpoM1OE4niXd6HHG32QvQ+md2cAidTrpWZR4JOM4j1R3GM2yOH/Vmef9
+        4LsOBsLNwzyfBvHf58ntq87/Dj4eBsfpeBrlCcZDdJrk8QS/eXv6Ku4N4qfd4QyEfLVvfy5Dvk3i
+        xTSd5c4vFkkvH77qxTS4gB+eqmSS5Ek0CrJuNEIne8/QzaOXo2Ryo2bx6FUnG6KP7jxXCQB31HAW
+        9zGJ16BGFvYj9JRO9vA//9FR+d0UlE7G0SAOvwT8OQZU9BRNp6M4yNN5dyhvy51VX+9NJ4OOCgmb
+        rDtLprnKZl0NehhdY3rz8HMW3mKlpLNwDO6ZTZJ/zILne7/be743TiZ7nzPwYig/Bia6F0Ezj7/g
+        59FtJK0d3Xk4z+I9+uImyfcmcR72hoPnN9loo74O8tndP690J6M06j35+od/daO8O3wSf/3Pfzko
+        YQmpqzdvLxX+7+rNqSIh8oe3V+rN+8ur0xN19Gd19O7j6afDq9MPW+L/ZZx/E+dJK/jzknRnOMvv
+        RnE2jGMwncMoZra6WRZO0tk4GiX/iHmG0EJcyzyifxCC6r1JtHedpnmWz6JptzfZ66bjsA++D6JF
+        nIHZw2/2nu29CKlDt3mP+tNs66DizLgLsNJc/9047iXRq040Gi0dzji9TsDU43gyDz//fR7P7vbG
+        9CCYgHllbLsGBeaNJ1kCGVSGOk0zrOZ0ArFUwUDWskOUJfMzjrBwXCo1/WF3nuXpOCAWMNAxemLw
+        kiawQlCEFInvQrSD3jkUG4l01YsgH4fxLC6kpfxkkKYDkBwDjYNbSN4+ZC+N2ZFzF8G38+d//vPF
+        nz5cvzt51//j7PBP37749ui3o5NJ8Obt6MXZx/3fRoP+n89++iOxn4tkTU67Ly8iEv6Cxk/xIlMf
+        0oV6rt5PCX4ELpF5BuuO4ggI3UajOURiPpsbxROKvnr08jrt3RlbgPRgMIXY1MjkwyRTC7D+lNRL
+        L7lVeIZg6ql+OlP5MFbCdsDklqmDT0hMUt/xTCXQmeMow3eg7cGjr15yD2jMbpIpJCLIykL811qT
+        dA4u8ULlqTrH5JNmI/3yMowgPLln6UEbLoRXR8NIJsEoHaQEpPSNNFpApM6y78NwsVjs9RfZ3iC9
+        BRrJeOCR6GgN+6ByvEhnNyF1JHpAVFdn/5sXWItxMhhCAe5/u99R0Qh/OZrcp8VP4mk0y7Euc5X2
+        mYBvMcZZks46IQbpDFQPWBNND3mWLgLSruVBMiGo8StioJfD/YKyNODqeB0UvcaGoIFeaEa1wUgT
+        p3HYGUnnWdCHyRNEkx5MADF4AjZlunGZ1L/7ziH1N3VKe4dBGregJ2gDHmUiffVyDtMY1ELbKDHD
+        ItZ3WFLbFcmkF39hqxBsYj7tR6ofBf0F/a/+WZjAVs6m0eTgDfqBXqU/Bf4oqQOLrtN5XofGzcE8
+        WwUwn8WEJwE8pF7UR9h5NE6CI7NV/l9njP3o72SImGVnbae/r4QIZZKxWBOoMsyzwz8C7pphxpDh
+        I3U9z3MIxQIutebp92Nj0bIJ97+c9egjdDy5jUfp1IxdsDilrmpolMevObiY6X7UjSEYb+qIlcSD
+        /oo1/jwDdmV8IWLJjH/VeUcGKkTWJJ0EZ58uFakDDNbLLQa0nkBNSg2pNo4qi+aLJIewWI63/qBA
+        mSm7Faa6qxKiVwJ/LZ5ZHM26wzqav15GFvmBhqXX0SV34sAqMfdL6J+xirrdeJoHdu/y8eoMexc0
+        E7u+6pjplO735llEAj/U0FhzyN9/o946CjueYQrtNIDVWF1LrLrYqiSVNsNO8vtnP0yjXg+KEX/1
+        kgy7yrvvkwlsDp7+yRRrUxQ0tlTASjTyMOn14kIh//uvvzz/dv/FD7S90DquzL0vE+6INGnU7yej
+        BFvXju7XafB2blYUbV0qvY6i63hESvxVh23FzsEp6SHsN3nqruLZ+En29feQKvRh7eeCVDTP0y72
+        g6OYttNpvw/DR3wKIDUoDWFOvQXud6KwBaYehn4oLFPea1UQFohCT8AcJzDs5RfZ/JqftIkjI6h1
+        8RLm+WzsDkQkZnWNkcns4VzHul7GxNfYQJdZ+Bx9OQxcAHwZag30MtRKydo3HjuHlP7zJUqf2dKv
+        mH0arIGhY6VcQMIjmIqfoaSPX7z4naOPv9X6eAsHBZHLqGgvBcSAhHEHMi2hAJs9eG1YL5okNIf4
+        WtS8q/6SWebRujxOWGTDeZbAWNW68Ii8LFgUppUw5VXE3VqlUmg1Te9qb9wcLGjPTbsRcjAdcN+f
+        dJPtmPp0OudHKPWqul4NQMDBczXJ7X7EAfq29MJnOIBem4LE4OJZP12MAh9cjFPeqjpwRyxZqwxE
+        2B0KIex3colNgutR1L0JevPujZBD+8om6oheqBO8KMgBqdASGotkEMNPxWxwKKhhn0BtLUKHaIIQ
+        yYJBOsL8x3cwr5kNpVm9Ns1tosDkz7opmEFDZ7pfckurgOfkYZwM4l6Qx9HIALet6gqtbSIwiybi
+        WD44oj/bBDXv90cx7bb1KO1zi0CxuKJeBN5K4bBkvjrmFrAVWtoFDKfpNVavBauf2wSaTGCEwNQv
+        eOlYN7XNSGT2AHAMIauX0DG3qFNqaXPMArgiPTRwj/AQ5ajUjmWoHj8E+iCikIeedaHBuWltkQ6D
+        qLeAC1bgvpaHNsHNYlKdFA+ZTzVQaVKX1NQu6HhSl5qv4XswzW1zO+JRIwo8TRyd/ca0ta2uhymC
+        OD0400us9oZblYfVWuL4G6gtd73/Ac+tr3bETbC4XK57xy2tM90oxWhzOHRA+cJOe1e0tj3rCAeN
+        opnWnefy0OIiG6c5HEjuWM+lpe1xIvIFl/xsEsCrT/QW2fKTblUX0triyC0CCOnCq2dEucXgUje3
+        iMIMhL+GNM3y+jr/4Lzzrfad7w6ATGG0ATo9tDl2EiuTmHIanIX2oWhtmwFn817vzgVNz20DzSbw
+        ozhW6iWeW7dRs/msD1Fa7Hou0QBJSg0tzjDifOMpvHIQ44tI7zavTJu6RFubwOeT3ixyIXND22AX
+        iFXmFPF1GOuTaaswV0v6GiggFNyfUdyy5/Ia8ChetM50gobe87rMJ2jIi/aZcAFzyZ0LPFamAYJU
+        XKFmPlQ1jLWFK6iPmB1xAfnJtC/vTJpMVlQ9WrYNGAqKweeccfwyRvKP8RyemTc6meuU3xULzg52
+        G0cXjQqbEL3l1Y7E0Y03BrjFqO4QURwy6UBCsQv+TE1MOjTtcBTWJ4pErHTkel2NZ1Rd0YsdgaTw
+        QIUtTpF2kI6TrnqLnLau45gxM+Qyp8uZjQg7nMMFa4j4Rh6qY2nUEXk47qxdeqSfls1Ioy5z5F1E
+        eQbKu8vkSlopmEmMxZS3HtptPNNVMGE3HY0SzhYS3jq2z0QZC4voX4HHTU38witghtdzpBlgTmTN
+        DihWJXgcmRd6yb6mV9XJslxxXzRmSMRDwtAw6WKvJQh8QJP6k25qDXCUzLqzqG8E1aF+bA0eTPtu
+        Dvd7MM8RuczvAgqO6hGf6nfqo7xT7+hda6iQ82g+0Qla4PtFPNOIkB/LvoHIoTetoQHdCzf0fHZd
+        EOITmtSVbvIDduUQLwRO9thqpSO+iKis8dSeyIMP6na9QwsiK4vymwL8fzRBfhw/9BB/4FxAdhCf
+        2q+eUojNfqZX34n+eIdoMbOlSB5GYkCJAU3b7mDpHNMgYaWigb2JOE1YaxoPf7lTvE7VUBqPiA3K
+        wgnFETu6U4cZdnTqjzpdpwbEN6Mm4wiZ4uOYVqeWhxT8RPodZWNxSqO60u/LdDJYG4whwX1QsAu6
+        je9E6lI2pQDBVohazaSjnTpnJeAI/yb9hdN0OkdSPyY30LAExIVtVxqaBcHriMLwRqw3Q90DKowQ
+        x0Pe+mCWYqMTdGfxAtHGVJtPFOSLRkav8CfqGJ8g7ph6zClDUcHK0JWR9aidKmEl+nuNjDprebCJ
+        eCQt9x48WZ+B7j6cxZTUzzYVuiefCRkNQvgP5p0i0OBKa1C4Q9pqWIC7gDXEaFho1MKgaly/HYwi
+        pK1H68xoEdDWZG0wle6oG3E03N+32EeU2Rn+b2rcGS9XgITmOZlQsoysJ5sAQhFjg8Db4gNzEqUs
+        GDT7NmFZA1TzMhRUNLsrj/uEmtxRu+RsPMFVQJSJmwVkksJKqYsOegsZaN664GV0DNiTdrnN/MrC
+        xVLhoAvyKBw5bI4Ewff/9qROZldiuHRphMYixkmeLAuKrJ8BMibclfxJvnDOH73GF8V6tvLTkdmN
+        p2QV+HDFyyItibhyBYoud1pMGb2y6H8wjCG9kO+GhY0VRqPAOQn4EIzQ5FecW4/zXfKqPuGEa0Nl
+        tYKEWRP6hsDwM1ZHEF3TCZiu2TkAO2pGBrJu9mPpsibjXFkt92ZR4IfUedpZuCJrEsdGD13o9zj6
+        YUWa+one+zC+Pz5YGpJuRM6vLo4Nyswe6mb1STe3A72HaIpYWVNOKdJ8dULN2gK5kBftwM8gwIbJ
+        aAQbKLIbvUvdCKuHGtuBjJTcbOjYH+f2uQ7P5cqNBWYhKNkWIms26GKrY2JYlSzIEzo7dMzvq4g0
+        YjYca2Q1rNlIP23VlZhrmj3m1yO9F7ayh4w5yyXOewJmRec2Qn4Z4JIpjTOU5tyDa7Rzc3W4jcXf
+        UsjaNxdQpvgtiQ/SvNo+EFJrh5061F/o5aMNoN1j1B/dLSLExIif6HCCnpYzblbMRkfU3BTyGDlY
+        A957h8jOwrGw29gMMHDeTZ2JZiJokml+079Uetg4lmV6VR/Ywi8zB6c10+xAPVlRb5abaQEv+Vi/
+        QEpgF6AsDIf5VvcQSme9IJvG3cR4nKTHnrqURtsto1s2BzbrPryORr2AWEhSpII4onOBjkqSIR3h
+        M7MR5JRLdUofurqphBQIdS+0BA2hBXlhBAuBKcSgVgJp5oanjmfvXoArQhJHliJaY7AjYE/kMByw
+        WSxPjTkKxHaluuIf0Noj+01+YKZNPdl/trf/Au7CLP/ahztPp2fjUdChyh5sfGdB2sdmoHB50EMX
+        WRJ67mhvS2f2Sl4RPNAnO0Kjn+Lke5kwZ9Rkhr4jMKwmabQFRZaMtWASGrZ/pGZ5M9ntovevcVaZ
+        YDmTUx9WnfXO0odfQfkCEi6r+pbpNIVmw5oPaD3O4oH2C2VhMulyejpInEc32tHFIyRQb+1bdYW3
+        RGqt9HxACsoVFjKyprKMnZ0cz2L4g3nSo9ITMi5rNdtPJcJlZIL+2IG9qQTA8hJz3UKQ4FoJmdBg
+        FaAWxZww1srmtUZAnZj2Eio8w2W50GCtbYsSYkWOX36dx766NHYxaR46hRtHNB4KsTQZySRHejLf
+        4+SleA5eRzWroS3ycHgDJwxmgztheQ5unHLDQ1GCtZ4mAuu62uiJa7GyHGtFnqE0rKHrF2Cbrnsw
+        saNQxgi8zGfGHCkpknP9qrLgKvqfsF6t2ZqtNi9WOIpGXjAcb0dJA8RkeuRk9X4pU/uT/bysE92h
+        uMKaaIz/WhyACe8GHNnl5TCi8/mFL9yEeZ8qjvDqBfJOf1TlUEF4NxjXZe5mAm4JE+8GOe8sAz+o
+        ymuYanQuFlt3mfZj3arOpbVNovnxsps3KHgqIGCn1+zZROxROSW8enj8qjpC6FaNdz88Xn0kwGAy
+        EeSbWZfjGbXBt8ttMLZpQ9z1O2naXbtAC5MV4ChrMoZhOrux8XkghzfqmN5gA8pvHp54SILqpXDZ
+        lgXKe2nFZkTEzMPjBa/sJCPXjeMmuiq1PTxOtzFO0DM+zhZDVsGf7CvHl9Amhh65u4mR0rIKaGqr
+        tCnmcVQ/5ti1SQq5pIbXiFS7p/c0IfifquVEtlQLtlMPvhvKFUMscEocLlsZ4aMT/Q5ROX5XpAq6
+        FlxLmxU/YmF0Mwko35gL87nIHsJtO1F/QL45jnsMYsQfcqoppN6YjwvsXULuxFJagmsy1sfn3k4+
+        zxFbhbmnzkmKUJqW9u2R1L28wwGJcXWBtooZUjFljt2QDYI36mIUTVgVELLHjmH9M2BZOP/JzVDz
+        9L2n8zXiy2LXLWHsDucDasfNZ0sVbXWBuVxBi63ga/fNmllZ4QYWeh8u9/YSA9iFVdmUbA82XO19
+        vnB809pSF6ezxxbekibidS/52mudrxkfc0KxLwxQBsZkmB1RFtV54TInBubutySlFxTVMUTKdhF4
+        pDOjXIyhgpRMMp+xMoVCJ6rIZangWZpxMv0KnjOqYBvCNMYW7ro8poqnZBUW2TjFmIyMsF95x1KV
+        XA+DO/EAts5UpSaPjfMPbZBauu3nwYu0DtGTMtWm4iFF9RyLqF4Hn+QrRSbA1EQEL93vfh7smaoV
+        lyUtqbK70pWIDzjbEWWgaQIyUofc8PNQahItxlMcO0ti+J4L8ymOxloIHH46v8ABIH5fmFB478fX
+        la5C0yqVt5IFlICFjWcG/Rn0eWMVVIQZZrfHUq/kCSBGkIGgDCb3gNrB6ox7UBUB9073UDYYaIZ8
+        Q91qGCyd6lhSgg/MACOZzeIi8UwflxEi+wYfG8FcU0JE9a2QIwxQaJFqJ8d1HAtKXgE4F4bE2Vv5
+        sozglhQTeW2jfSjCtTrExUaeZ/QuB7q814QmZd7RHDNMpoGYblR0msLjeoKOanNjmAw/MdLwLZeq
+        5l8RG91HnzfFDu64OWJUI04co1kt/ZCieSaG6mbvHcuPbLnWY9dsRjSznK5SNk6Y5+pqXwRAU4Ys
+        YWkWvIf4mw4vpL4Q6KNi5OQ30sTB1hVEMnNJM2e/AT8zAdWh/sYnAIrB/SIGSNKRiTVA5Q0nUuew
+        JIZj3v3CB2TnaDKZw7NcyjSxc8Pv9AbUIwfK89NMJrbHgojlcEiZsv/ZANBayWlXbAf8D5mZCSpJ
+        o5ijTWYzs0IVpqV99UCsHOTF42xT5XkjH5FHWS0X3WFZ+AWfU2wfcMRugqNWRhiURZ36kT7BkTv5
+        hMblYL/lbqcxp61ENyxhH/SSGTJmcPGDMFcJb3ViXi6bmF0qyNVURlbNlPJ7ULrFJBScR1NK4OGW
+        XwCCnBqiyXhBaSJ3fqRcY8PHuWvFTsmtUOE7yejziradzlXFkq4vJ7lug2wYvSkgP4IxQFEWsWYH
+        FUaPj2w+5LF/R3JJiLONVIARHQaSCiYAP1JzKeELvEKXmjTtvnAGyPGJxsvPbw0LVn77t3WU/JsI
+        QYmdNES+kkneOkrGWiu2Z4KOMT6KTVfrqBQOIHeOHeqQw2sr6tgDkG8ph1tSIEyRyFITekf1cXJI
+        uaU6C3vEx/9bM6ghvYxQvMmG7HViu/Jqg80RQoccWhUgCBryE3VvNWFFD64Zo+mwqifcOQsiyABc
+        0AHzD2FL3ByCW0sQchAcKqLy2NmsfK8OkRaKH8I2dH9Yp8Za6dwITdq992PUVYRpV56NFUjyNutM
+        fqWWz1dzDK+jDKfnWXJeJykOjGpCHVG7iM4jaa/Twc8VptXwCabaN6siuWVWXrMUt3zh8MTyX9b8
+        vHFOvpzyphXJBgKh4rP5JB/T6bsie4qygS0OrJXLW9P744JbwBYI2wV0/dMdb7Mj1J1edFHblCgg
+        qL5B0SjUxzikb3i6I/XT4afjQ3hLS7VdVwsGIW9TIsEXDnbU5zGJMR2sYmPeuuEl8iY5WOGbEuU8
+        1OMmT2rZThEtEiqJFUyOmfa72ORTyd651BloXkPpYbAlmmvkzujP+hJjPLbY5mxIVUMp4UONkiGQ
+        MN5DTXAFlRCFMziZH+kehhE/cpMCfmjy02yVzGm8KKqoSB1iWaVSgfgBgY/jL7hmToCf899+4Eb8
+        EufQf0YMy9NO6CLCwSSCZvMxsqmsR0ykAuxsPr55aV76kN2BQM2oomaZa6nFYdk2xl+Jh/o0j3ZF
+        baB9tCukJUJdIxIzIS9SySl2pFuXu8NcdnJJuWru4jTH2WKc/htVXMbLlHPxg4q7eGf6uYCwDqWS
+        jq5r5E2nZwPAk/E1LIFly+r8CCZAk2VlTevVa30DxGrGASPKKma5ccD4viaTZQfGwc6QlYNZ5M9H
+        HbqZa3adUxYFXihUo5stt7VYpK4wY3aHKVKRCic2YZziRO2Ad4daQR+6rmxC/X3xhY9PHw535o2A
+        MiO55I8xwIgbFJlh0vrz4ogaR7K8UeLIj4kr+5h2DXIQjeG1AR9Evdskg/cV3Ih0CMHpULeBEdHm
+        Q283AjgUocP7P9TNM7slXrxH5A+iQ5Atgi8dwaJqgemIbqOVSx7c41kZZzDiXYvICC2w+Y8mqS5Z
+        fTpRp3j+7/9KnQs8rCnlGOYNdWNTRyWN0gpyZz+8ZgnXuq97Rl2ZV/ePssB2Ewnr5HZXRcNR91G1
+        iiSYTknksLi7FdbrUL5SlxDASFzUCXnudtihikOTFSuhfXr4gNdqZt27SMqKki4NS9OUZmpzvp1G
+        d6XgsDyVmcMwhgG1xPETI1jDWkxm/dQ82sldM7X29+Fn7A3hq0AHN7TXR0JSyQ8ISwrSWCck/cjf
+        cnVg2jiOp2XTEoYVfWtx4HW23v2zKS6oD3oX1NDW6vFofqdqaHr3tz6m2xiVEq3sr4PufIb6MvPR
+        XBOu5CE7NZOlju1nZSYQ2bgTBGt0ounFjj+vZ0PXyEazS5+uFmV+C9nSoiGDeT5Duhnbl+DKXAe/
+        6igio4xtTbBj7txiZLRLa8gNsEGmy7tZydbRei2vH3BaEXWH5p/r8wJ1jA5nuTr9MoQjP4cVMHfK
+        2htaGdHDy9ax0lbzoZ1oChWI0qnIJAoFyItNJQNbVG4hAm5AlIkv6QvBHTupgm2HENq/isHottTU
+        oT3l1YvHzefW1zuCFsXJfsQi6GE3Pffht0dCYRybMP8ZGtQlN+wGwng+onqkqAQoM35un3fTv6UX
+        5e1IgR/rIUOYgUoC4bkOaxNG1luNmo0jIypsuxqY1asCSStFmLLqLelFWm6UI5eViNVJVMl7MMNa
+        YxrgUB9k+206uo11ecLXMYlwaSFqsU28xkBwewkL40DIcgJjQQwA2x0LjfW6fkm3IR/Iwu4NCZKU
+        NGlCelXAfBQL56D0pewmhlfGx9DHyjWfp8EhkjM8Ni2qQMmkKCDUGIFHvgEIPrY/1lvU04DtqDoP
+        +xXXMvIVKKNYCN2OhFMDeUDnCKoThix8fq+iHFXuZs5lmoZcW0M2hgVFjfiihbqJUZDR2hYSR+LL
+        F7axMxpQpOp5o4Pp9tiyg1E1NEfn1PHdDuemigmpM0qsJ4pNhykfSZziSJq2ZVfgRm4FfKe3dxfu
+        b1vEF5YY7w+42KrViCvQZObGVJsf3Be3LEagome3KsLcl2jc5QKtC5+gZO3VpY7a0NxbxrQeyGTW
+        xWK2OeadB4X19t3WC7uH/NkBriHTKYLMrkjLi5EWAn9EaYfo8MIJ/8omFtoiHvp39MLsFptIbGsM
+        eHYKkDy2BHoZn7odjD2N/dbFoXAUbbKxd9UIlK7sq0o7aOFRqF/aSGG34sKn5VDA3VB7+sGFvRTZ
+        UXq7dMJ/b7XolvSOyb6lyjPIcmAbPCCvlBZXmFB6h6OU8k6d0bs6dGPHsOJcs88orZQu7L1/4GZL
+        fWJKKHssjeaYVBWcz0wrdRpPBhyyCFIYHkbynupGxTldPIat56kCIGTVqCUXlThE4TjRfld8cAWb
+        NAhZVHuujqSRnVEFhqHywQs5wmszuF5Ls5Kzu3SWnHJReCPNuOwEtsnHogM5Ml5zf4tNuqJXdVib
+        MIhNDKQKxzhkmnSLw1KXpomPK5XhGBhG9GB6wSrmdnrcK5MrnLmEuw6nskZx33Mf/bIKdjJUTlzG
+        7sSeiLYV7ggPZqY1Fviy/sNRhDvCRxhqJncpaOK+Q3P4rmi2cJhx1guX5vCqiYNF4UgZe2UjU5SJ
+        LE+BGJy+Bbo9Km7RoZJWENMFu0gviuWSRK6I1n5ObDdbQN5fkBQylmppUkkNi++ymqSQufpbk3hn
+        GFqo69f5G9CXpSK8IaP4FnHHgHhPKCjZrh/0C0XcV6eQWWXMgmtE/VKkzIvywqoC24iPnIKT0uuH
+        ogIldbyJsDfosVnkdIwS8nbNV1eMYVPnk5V8WUHvXnPswNS15OBeiSe3Ce5DpPAEnnhIXAlWsJIa
+        cqSo3M/URUqHM3bCeC5SFNRyngM4xYIMhhY5BrA2ENXSLEhRLYcy6nAWq0v4OgJUJI3JtqNPq3yC
+        FbGBgbd0cuMvMV1ThHLNKe/EhFCnplW959ad8VIVXBg/C/Zf7H/3Ow33veKnlgZr9iWYFUSycV3p
+        JOX6YwLcbEYwFfwWZ7u91ck2WqHI4UdZBj3RF/KwM2rqzmmFQsoSwzMADo1A5GqoNB56qwQ8eyzo
+        bZ3IG0pZA15DXcZjQl0NnNfaUnviXgLBoEP3MSDvXx4FOF3BoCJNgPq4/Stpo3n2lvv1VPk1oHik
+        Sj3iZ76YdBLdHjyiG0p7Cf2h/xWNQzc0x7ODR/Tfy18FwZsUd6K8iWdpEBw8eokfqKT3qjNEawDj
+        P+3Q76kV9e2yDC/oywVuSqMXX73sJwOcU9TGG3qDvwpmBWo3HIFTJqe9JI9wTYuaoMjLqw5BwT1i
+        OOncUQSNEcKPYNrjXjeFFRSjlAC8cDl8nwpFvDJlzlrcxiqhH2b2d5RNobjoPDIC6bCkPESj/FUH
+        uImuf1l8lc26rzp82kpfcxYm4wGS8vQ48UQ3aQbPngfjFCc7sF2cDDooL0493Ks7uApu8hTOTfQn
+        OHJ84FXnyRjhPBQtzYffq2++259++Xon8Prz0SjDVV4xKk2sArn/4vkzH8xJil8n0/zgJQiktiKb
+        4ll4HdF9r6O/vcYVSH9AEDye0fhs9zL9Dn2JGy3/nE56lnvsnIeG3cB5VZ6EaZtDVeupL/W1lBdh
+        1fJvmBu/+goya7h/8PzZ/rfKCHDHeUPeJP5Blv/qZYgPDY9ND47Sa1w0MM/HYEnUDc58P9c/fRlO
+        ix+aRXU9z/N0AupECheZ9l916DhzuP/ts9/v/67i2rM/Gc1x2ZH+3bs4mk3UGOUvRCABBCi0npwl
+        8aClBAuFkxnUOOp6pCTnMkh8bE/14nMJv8BiJb8H+YSZ8KWXIiR4kQ+fH3yihQ0/CH2Lgm1Z/h8g
+        4nMtcrRw+Yy7v3FE5LbW1yi6jkedg2IXRW5iEg4SRFWf6XgV7dcR//xe8ao/eKso74KXrxWALn4J
+        6pt09FdMCEy/w1S0zzXMVOwUS4L8150DeF/pNqEUNWb39jZWxvBkok6C6JVIaedAXaf4dSkZzMWP
+        5anpb8XLbgDLU9PfAmmb0Ad+l8emP3ZCo7BdFT/Wf2s0m2gsBJK0rJB50LMp/4A2ouX0P6LUziNy
+        K1LC/hVOPPHGMVOhLF+kirKqy2RDaRZUN48w3SW5otUcQLhLiaUJyrnhZgij10iFHl8dZqzWln18
+        iqtD70TSoEciGy7RBUQepBFsWm3V4FlZKJoUwKqKVLC82EKV4peFmvQqUxaNxTcrdAKoyNWh+Zpa
+        o0k/Tx1NumVfe9RJY/UJKwgC0KqadZpsKdaiyFA4GuLl9ZxuahzH42uSYLRYiwIt4DZiZx41GCoZ
+        XytzVlPBHQEvHN4j43Yw5O+uyTiixGrYShCrFLuFLOvO8ZU+y6quUdkyQ1yA8hu5xiXMCPPYn6Vj
+        7mf/t89w2i/N1ZRLQugQ8ItnulXQAZselzNeEYIiV4r6Q4o8hRt1OB/sqee/faqeP3v24ik55OXF
+        U3UIm+8m2pPySi4VODJHOF7Aa0qx5z5iHzP1gg56k52oLqNZpD5Qct9sr6PCkt5nDnD0fmV9+TQ/
+        PrG6Xy8RR1Tn8Rej93kxDV8c1BehZwVdJflITNGXcJWmk8FBiVCQHXKjsn5Z6rOCJXTZC6PXK+Px
+        WR+0fsvGByM+rSDAE5hBxML6FQ6zFgLJbLgo1l1IQrnXnBqQTtVwDvsk6EYwrHvEjnSPOql46op3
+        cHvsJBjgojdFBohKsqfEZoBOGGQk5WCZ4xJy/ENWOpFH4XZkWg+I1yo5ZY4gqMKJNtVLqXNExMg2
+        d0YCqzcZJ/8gvqY1oy8btojsIU8XgISXsSvI0pHcfawoSqCyCFuBMcQ7DDfaZ6guTImMdb+LDw8F
+        v0YBEvA+lpGcb2DErmN1DR8eZLC2tvb2CmcUEyOc9vr6qh1y/4TzrL/IqCMGYQoz7+GrjlEf+Fv1
+        sW0IcJhuAmNIRKq2a6itc/Dvk+ts+oM2SeC1wXYDVpZ68uKbZ3sv/nDEVwIxHZsj1u92U64iTKcZ
+        sRVGsRUKCnK9NLoe1NxYfw9EZzGWhkH1+f7v954bVMGSiKthdmH4kMXJLPyrNTY8rWRtbfH3zjI2
+        1mxpnS1bPbhz/UbUrZnFtSsCislQhHUUaCYJw4gi20vVzXxeu/a1EgMbZYbFwF4xSGd0sGuski+N
+        CbJD7AdrEpReOwaG/YCo+8uyGYBPYREssRpICRcfrTEbxMkSpNl0Ft+hWv5tMjmJf4RU/nh59uly
+        iS2xQwitWxjNByhmBzaiv1M/zvacRI5HIROj84tXqP/f//l/jU6tOMweUJli70oOUwVZy1H4CNYb
+        6hizqolQ1AHaA7qQRS4JbXtjPHQPfqIvbzO3vWmPn+g2qBDoLao6jt1EBO0HNeR0QMeNoDpT6mZM
+        Xq0R2DjAbm1c/g6AIihD3GnxVFGMNse/pEihF5OZ0n4q3YbqgNjswlxUXGQLpiNfJk5F9tQigTrj
+        sFT2y5DFy/y3oawB8SZ7RW0haeFkwfV+/7+oZTVZSNElorYkjtdI2sKlZE8+aJ/nPXZq9U5bF6h1
+        kK6WECH64xz3FmTqFvGXyeB/0lbkEO5GSQT9lIx6o6QPFwPZLz2YIA8oQ69gosPKw3bxMfapI+xC
+        IfAgosYwuyHe8JggJDTPIIM0ljB6SMrxKRm6rhDydxRB1F7G03xP7f9Wjwq6DQbkZU5WfYa4KSz6
+        p+rT2z31aZiSUEYv6HKkkBCHH9NOAfrwuwD/83uPe/WpWgyT7lB+gj00ehjj10Cbd9c6A5i3Ca6k
+        /g8upggtQLhANsHVqeBFTCcj3CtEAjxDEfRfhHVbStAqGN9J1LZrmVJniar180xeifuwxq21fckT
+        Zl132hdHUSmS+LT7ZB+dszugtk4Rm+JHv78ORqcJcpF5CCfzGba62Kf0cH8JpWSQ25neOL2T75zB
+        kg+Q3pGrkf74Ch5fQzb4E/U3docmF7CGhI14Uw/BsgLF3E1b7QWHUGK6J9lx9w/zfJp9H4aLxWLP
+        vN7rpmPZeI5NeWTem3ZUTm6LVx3aARGLTpAUAwNZZahngz4ttv1I9aPAdMd/L/A+TPD/y3DLYUnA
+        TPGgpt8UWG2DjO5kOS7i+CWq69Al/ijmsmQM+DaGRHgJLX71lbiMwUzkxVXzKZHqhQKNxhBI8Ft0
+        ZumioyNLLiegGRv5WWY9Su5L+rnhELPvdFgAIZv9Z89/O5RQUHANIxLuE80Zmp1Yk2u/ALwSmLL3
+        qJEKn6J2we1/a2KOwjju9zzzaviic/CnJF5AwY2Q46BdJTYAZaA+RsIFZDNF6xGTYnfjiT2kgngO
+        BC75clxoxBg6qrVin76eCJ64lVlN7nBk+KQX2Kmq9n9HPshmBDjHkBD+wR31UJTk5KrF4Kgnj6ag
+        78X3RgUICB294peOvRQWajL4Z9+RYsw4RQyBbREMS6e/GP/vmw+/ad05XbBIoaQH1RCPe+uGbJce
+        mZ3Ff7T04EWDM3uBNaMsk8gXlUeOl8C1DULL97X3juSlZVgwnYa42Zp79vtn++aOoCEcBzBK4OnE
+        Vomcd42pv9+c+ivuG0L2Fe0L2dIgg0WZPMpL5DhQ/c1GHLcpy333/PeFTZAZS2DN0OH3p7Dp8w3Y
+        7lOCgCXc++bQGXmBxTLbxVLbcNa/e/7N5furo4aj/Kb59OopRD1dOMHPIuzaj8gSPcL1wH3yJ0CT
+        HInPfPVkkkfU9QeW1hCvCf6fklqDfWQjFVo70WqzlhJWDltJtIIoUWc+FSnq0q6IW04P3lHo6iN/
+        1ENkHCioX7PqPKGgFBUKjPLvD8f7ZI7VFBF/DYz4W3zAlrCgohF69JLiT1BehEufkjzohB0HpciM
+        eKQDqvQWJdVmuXzNKtSDMSl+zl0S88sxvbRGrtpdVZ+v8AJNDvIybWzEqrU16eXV3liz0xVOfK7D
+        6RtljbnJdkxiy+mcHz3nH1cDEHDY4EExI57m1LLgAb0tvShsOAIm/5WSE7RZsgZkUZ7YBxfjlBu5
+        VB24I9OttQwibD7qZSiE9mKwa+wfb/iMm8zBIaKKoA8qcNMLdo8W5AAPtYTGIhnEqb6+51Bj8Inb
+        WoR+Hc2gIbNgQHvvSXynrYkjaVavTXObKDD5Ef8CM+hFwHS/5JZWASPHCXeeDpCEmcemtvURRWak
+        VV2htU0Eiuq5R+UiuTvnsut5vz+Kaa+jSWyfWxyfFB4Fb8HjImCl/CjYCi3tAr6NsmusXgtWP7cJ
+        FFuGaIzdcsFLx7qpbUbqInYMwDGErF5Cx9yiTqmlzTEL4Ir00MA9wsOokh3LUD1+yO0BAjAVGpyb
+        1hbpMJBcVOE2nZjaJjhKrsChgAzZFrqswWtpwqFMNLULGudBa1IT4G1z29yOPdgo/vsc2c20KRGa
+        vzFtbavrIdJXoC8qrPaGW5WH1VrieL6t0lnvf6B8l7ZXO47IYnG5XPeOW1pnOolvRsh/6Tlz/o6j
+        ntza9qxTcWak5wmvnctDi4sMQV34YN2xnktL2+Pku3FQRieYwn0HysqA2RuEVnUhrS2O3CKAm2hu
+        kfys1ZnFAJtmbm4RBTjy4VqFO4Xqt1fW+QfnnW+179xuAzKF0Qbo9NDm2CFGEIPo3pSY70PR2jYD
+        zua93p2zxj/Qc9tAM1xA71qpl3hu3UZF3mIforTY9VyiAZKUGlqcYdwxM57GbDwszGWxuD5G2tQl
+        2toEjvIUsyjICsjc0DZYxG6zHCHXgcNYn0xbhbla0tdAIUeRLWQBk1RxdkTAo3jROtMJGtp6c5lP
+        0NDb3taZcAFzyZ0LSgmm4FGJ9dxTGpiVJgcu13ij+onU86XPdNTsTJqMw9UELg0XbOXq6VPWwi2y
+        rvh8OofKDTTzRicpnFIYvfHp1jWjo9c4EKcN4iNyUn7C466631XpxwajsD5RZM6mI007PSBd6OaK
+        XhTscq/5wlRhMzFwbwc+RRZHOsZNUm/52GYdkMucLmc2clDqWgR654JzVoBeBdGoI/Jw3Fm79Eg/
+        MTNv26VO3AflXXpcFen8NA9Meeuh3cYzXQXjJE8LWTgZKaMEG6KMhUUTXYHHTU38witgogoh8otA
+        M1mzAzpkIniYAjqmrMxrelWdLMN+jSZtFRpIhe/hdlbkGmGvJQh8QBNuY5Wm1gBHyaw7i/rmIP6h
+        fmwNHp9rhJc9wOELuuYuoIwoPeJTOvOId+qjvEMxf7xrDRVyHnlz9SunZa70cZ26jtgJB0L3wg2N
+        qqgFIT6hSV3pJv/4XTnEaHDJl+34sIe0NptPcCIPPqjb9Q5Nh0wZCpkj0o/E5sGI4+dBD/EHyh4R
+        bj+1Xz2lEJv9TCvME/3xDtFiZkupsghkjUai1LY7WDrjOtBnkgTYmwj1oRHoFk3jYXN3itepGlwO
+        oseA20GyUByxuI/vMMOOTv1xTvaHFqnrurJlvqjgMK1OQZfV8DH6sOnsV/p9mU4GawOGgsweIV29
+        c0CAYCt0G98ZkYvwcESdsxJwhH+T/sJpOp1L0a5AwxIQF7ZdaWgWBK+j4kz2stVdRd0DKowQx0Ox
+        E7ohBasbVRMWwTUuqxQUKMiH7CnJwqULU7Daj/EJ4o5pzR4gA9jFydC1MXZsd+FeYdJyzlQeScu9
+        B+92H844SQWAAgJIPpPC4pbsB7xTBBpcSRzlYftm/CJBbT0swF3AGmKgRntyC4PaEYwinqyhOjNa
+        BLRpbDzGtVO58UTqFKQyO8P/zeUud8XLFSCheXbr6eL0CZUTFWYyCLglfS82qzdaW1AGqH6BnE2U
+        +iiP+4Sa3BXskrPx2qgCotPXlObERXQhMMswL+gtZ8vrI/4O0Qmk/FdFhFobSawqMryywE4cdAkS
+        E8Cl/Z1J4MdientSlr8MzpEYLjqN0Fh1+YtM+YorXHitWaPdkdmNqbAKfLjiZbkY7QoUvZVoGT1X
+        zFJDw3lbgVTWBGNIr7+TguYLdrG2pmkGH4KQ+oO84rQ/rCp5VZ/wh8QWGNJVmUF0jeMiOMCrMQV2
+        fIPmoWn2Y1lWZqTcYBxYhtkFxaczXLJDOwtXZE1QXcsiKu9REkjS1LDOkVqP9z6M771kinQjcn51
+        UxO4tMlGn3RzO9B7CJvoquecUqSJcELNWoxcyIt24GcQYENkOcIGiuxG71I3wuqhxnYgIy0wGzr2
+        B47+6uc6PJcrXY5sNPv2HIVcS468yShASQ2b1VRUFyKLR5FVq475fRWRRuCi28RJ4TvUT1t1Jeaa
+        Zo85LmOU5EAreyjj2HKJ856A2TW7jZBfBrhkSmNzNDdr1jHaubk63MbCeilk7Zszt5+gJCc0r1bJ
+        2tIRhx3X/cF9KHd6+bwRC2z3GPVHd4sIMTHiJzrYo2lxxs3CRkfU3BRykbsemqx2M0AU2zJ57aHU
+        r5a6FkwETTIhwvoU9TJzeC0Rs9zMUgMv+Vi/QEpgn1skLQyH+Vb3oMtu4JJ1KgRuPE7SY09dSqPt
+        ltmpbA5s1n3orzfsqCQZ0rJiw45uKiEFQt0LrTiC+8WZbcHilFpRRM3wAIE0cyOmBSnqewGuCMmi
+        jjXZbXIkvjI15nQa7xNVUdma7Dd9hl5Pm3qy/2wPB5bo7k+udlLFfZl0KBisyh6S5Ux35LjHOukB
+        9Yh0ri7vX+mUVMkrggf6xEfCLdDop3QrdYlnz6jJ5dhdjragyJKxFkxCw/aP1GUVFznfEuJNDpTh
+        cJ4lyLzIwqqX3Fn6tK++8gQk1sFYWjXAWxGVR0igPKVRtdLzDaSgXGgtZGRNZRl7PjmeFZBKKar8
+        DFHr1FrN9lO+N9YoXbp7mOpJlGTAZhKgETKhwQp3GnXnhLFWNgYB3GWk20uoeORkAybfFqXl1XV8
+        HvvqCtzFpHnoFG4c0XgoxNIEd7kRx0V6Mt8n1ukY1ayGtsjD4Q2cMJgN9E1sHNw45YaHogRrPU0E
+        1nW10RPXenRcg83ppuseTFz40JFmFsHJZcyRkiI5168qC66y+glrj3t9N1jpovWoJcw3qaHaGZys
+        K/CX4vX0eVknukNxhTUTvdUBmPBuwJFdXg64lH7IRTv4PlEb5n2qOMKrjfp3+qMqh+4S47rM3UzA
+        LWHiNvmhm8IauYZffxyjVJ8JDaGCI7ciMZJb2ySal/tCu3mDuOsnqF1kQh3mlKw4TM/k1cPjV9UR
+        2uyuxLsfHq8+EmAwmQjyzazL8YzaFM7BUxuMbarRh9sdHh45oIV5DFDTIBljyzK7sSUPgBwZaCgJ
+        moyxbeE3D48frsTtpbjPuyxQ3ksrNiMiZh4eL3hlJxkXEaOYr7DaVant4XG6jVFohn0Ktc3nn+yr
+        NTvQXak6j9zdxEhpWQU0tVXaFPMZahxw7Noc37ukBopUu6f3NCH4H3fLJ+1VPb8TK6UH3w3lhiEu
+        x+VJ3TzBE/0OQUF+JxspYnXrqoSpUXZiEKotIhZGN5OA8o05XuoiS25b1ENGvjmOe6D23k9xTgfc
+        pQACBVcL7F1CtolrMtZnLt5OPs8RW8XWAfX0UYqQ0rR0+QmSupd3OCCBCvhlF1GrmOEGDRFjjltM
+        QmIobsiqgJAtWc8PjyV7MthZS5uumqfvPZXsEV8WRwAIY3c4H8ylA1XKmuVU5lyXK8DDjnPOfbNm
+        Vla4gYXeK7y9pYVVWVbbg13jfZZLFMU3rS31D5xy4jFPtqSJeN1LvvZa52vGx5xQ7MBwDw0UshCU
+        fIaOmuPbErl7K6M2I6UXFO5CmeVDXEMhxQQoq1rKLTi6l5ESnPiMlSrikebrKp6lGSfBWebIBrL0
+        ftiGOIQWQzbS5s07JiMj7FfIg9cjd8biX19r9cA9cScewNZ5jMKxOWr/8d7zAm2QWrrt58GLtA7R
+        kzLVphIJxGWcFlHNtnR9Ocl+MgGmxjl56X7382DPVK24LJmqJXelKxFFmj7IbEeUk6YJyEgdcsPP
+        Q6lJtMAdOPo638J8ik0a10+Hn84vcAotQT1g1NQ0JhTe+/F1pavRUOszOQqhKPl7xbMIyVDfVZNB
+        fwZ93ljhArySMMOa6fFaLHkCiBH0okKSFrauXHnzjHvAJXnooRBw73QPZYOBZsg31G1kfcgSt44l
+        8k34akUtmc3iIiFFH5cRomuHqAiWFsw1JbS1vEWnAa7axUHbGRf0L3v0CkpeAfjHvcs9hbO38mUZ
+        wS0pJnNuA7HhuhBXoSPL69jlQPdNkwkr847mGFS8DsR0w50H0DLIkBGWOqrNDWUCEpPRpcraDnlL
+        NyXIr4iN7qPPm2IHdyFq78HLb/iq9EPELstBVz2aY/kR28/EX8eOP5qimeV0lbJxwjxXV/tGqDYT
+        qyUszYL3EH/T4bHwsHfngKuFONi6gkhmLmnm7DcYO3+jDvU3PgFQDK7pimt1gJrtgmiAyhtOpM5h
+        SQzHvPuFD8jO0WQyhw+5lGli54bf6Q2oVwr+kmYIsRyEP3CyD8NhA0BrJaddsR3wP2RmqALxCJcx
+        mYIMZlaoJK60rx6IlYO8eJxtqjxvbjI0Xlxl4Rfw7QY4Yjehis1aFJZFHdfsznHkTj6hcTnYb7nb
+        2Q26YQn7oJfg/iHcyaMjqj/yLV0ab3ViXi6bmF0qyOKCI0l+LOGZIatmSvk9KNdjEgrOUTQZSQ/c
+        8gtAkFNDNBn53t87P1KuseHj3LWar+RWqPCdZPR5RdtO56piSdftU4RVtA0jUqtiONftoMLo8ZHN
+        hzz270guCXG2EfthxkBSwQTgR2ouJXyBV8gd2rT7YkMhG4zGy89vDQtWfvu3dZT8mwhBiR0bRL6S
+        +dY6SsZaK7Zngo4xPui6A9l0tY4KU6cP/3lp++JQh95tRR17APIt5XDLJRWmSGSpCb3L1XSISLQ+
+        XkN6GaF4kw3Z68BdebXB5gihQw6tChAEDfmJureasKIHfWvcWYSmw6qeKK3LKEBxGpx/gV6eYjOS
+        4JpshBwEh4qoPHY2K9+rQ6SFUqnpD6Uf1qmxVjo3QpN2Wf0YdRVh2pVnYwWSvM0ytz4vn6/mGF5H
+        GU7Ps+S8TlKcMtSEOqJ2EZ1H0l6ng58rTKvhE0y1b1ZFcsusvGYpbvnC4Ynlv6x5peOcfDml5UvZ
+        9wKhono+ycd0+q7InqJMfIsDa+Xy1vT+uOAe9wVVxIim09Edb7Mj3CO96Ebwl0KPCapvUDQKpbsP
+        6Rue7kjBm3Z8KDXy67OwirxNiQRfONgRNbYpGEqM6WAVG/PWDS/hGxcrfFOinId63ORJLRM+2BGi
+        RUIlsQJq+3OOmTbPbfKpZO/gell56yPpw2BLNNfIndGffkzMgiKc6D+zsORpJ9NvKCV8qFEyBBLG
+        e6gJrqAS0pWhyBBDM65qkhXykZtwKRM1+WnWBlVCqUMsOEgF4gcEPo6/4H5WAX7Of/uBPwC3iHAw
+        adfZfIxsKusRE1kFO5uPb16alz5kdyBQUa0fhwFdXXJJLQ7LtrBaKhufhU/zaFeUzFcj7aNdIS0R
+        6hqRmAl5kUpOsSPdutwd5rKTS8pVcxenuIsXFwAC2tgcuxETo2ynWeVc/KDiLt6Zfi4grEOppKNl
+        +lyNvOn0bAB4Mr6GJbBsWZ0fwQRosqysab1aBm6AWM04YER50S03Dhjf12TW7MA42BmycjCLItSo
+        Qzdzza5zOq5GQek/48VyW4sV8AozZneYIhWpcGITxilO1A7YRNN68NB1ZRPq74svfHz6cLgzb/DZ
+        JC75o/FlblBkhknrz4sjahzJ8kaJIz8mruxj2jU4v8Ejz3DTXmMZiNOzt0kG7yu4EekQgtOhbgMj
+        os2H3m4EcChCh/d/uIbd7JZ48R6RP4gOQbYInjJDbNG0jFMabxKNBaWyFO84gxHvWkRGaIHNfzRJ
+        dcnq04k6xfN//1fqXOBhDW8n/tBQNzZ1VNIorSB39sNrlnCt+7pn1JV5df+oLFFnp1cnt7sqGo66
+        j5JUJMEyiFbk/nNY3N0K63UoX6lL+cqch3e2ww5VHJqsWAnt08MHvFaAqM2SLg1L05RmanO+nUZ3
+        peCwPJWZwzCGAbXE8RMjWMNaTGb91DzayV0ztfb34WdIB/gq0MEN7Q+RkFSyL2FJQRrrulI/8rdc
+        HZg2juNp2bSEYUXfWhx4na13/2yKC+qD3gU1tLV6PJrfqRqa3v2tj+k2RqVEK/vroDufoWbmfDTX
+        hCt5yE7NZKlj+1mZCUQ27gTBGp1oeum+5no2dI1sNLt8tfNKUea3kC0tGjKY5zOkm7F9yV4L4fM6
+        ighusK3JfowHpOIAG+TYBntr6+K1vH5AhJBDA80/1+cF6oQ6xEWVp1+GcOTnsALmTln7bTRxMb32
+        LwoViNKpyCQKBciLTSUDW1QI/dtCBNyAKBPfyBeCO5BSTW3QiwIUvIC0QjK60LQ59T2DCaUtNVf7
+        nvLqxeNuekfQAgPUwguxCHrYTc99+O2RUBjHpvczNCBvkBp2A2E8H1E9UlQCFOKf2+fd9G9ng/J2
+        cOIRBX6shwxhBv1ch2V0KOsfZ7vhE6h6q1GzcWREhW1XI5mvM4swp8XbMGXVW9KLdHyoHLmsRKxO
+        okregxnWGtPAvT1eRvE6RkXbyW06uqU7gbVNvMZAcHtxLp6XDk/s3dK2u4a6fkm3IR/Iwu4NCZKU
+        CmtCeoVVIoDf0LktnINCSiSlSZoYXhkfQx8r13yehpgUoJDEGR6bFlWgZFIUEGqMwCPfAAQf2x/r
+        LeppwHZUnYf9WnUZ+QqUUSyEbkfC9iAP6BxBdcJQNITfK1Q5phMEO4RsDAuKGvFFC3UToyCjtS0k
+        jsSXL7hnr3aIV9XzRgfT7bFlByPHyuGQIZ1Tx3ctYkKqCxB4KzcdpnwkcVrcIr8CN9Jw+KXe3l24
+        v20RX1hivD/gUqxWI65Ak5kbU21+cF/cshiBip7dqghzX6Jxlwu0LnxQrsWx9upSR21o7i1bxh7I
+        ZNbFYrY55p0HhfX23fYiBfmzA1xDplMEmV1RlzBGWgj8EaUdosMLJ/wrm1ioWfWd+R29MLvFJhK7
+        0K3eLY0tgV7Gp24Hl7ZiDg6Fo2iTjb2rRqBPZF9V2kELj0L94h2lYrnwaTkUcNfvlEt84wcX9lJk
+        R+nDbCf891aLbknvmOxbqjyDLAe2wQPyShnrVd7hWJ++F+aM3tWhGzumkXnmErgL++8fuNlSn5gS
+        yh5LozkmVQXnM9NKZIwnAw5ZBCksCmvk60bFOV08hq3nqQIgZNWoJReVOERBD9F+V3xwBZs0CFnc
+        OFIdSSM7owoMQ+WjmVJA0mZwvZZmJWd36Sw55aLwRppx2Qlsk49FB3JkvKawjzJJV/SqDmsTBrGJ
+        gVT4GIdMk25xWOrSNPFxpTIcA8OIHvGzKRQ2ybJXHfxvrnDmEu46nMoaxf28c1C9j35ZBTsZKicu
+        Y7eixd6HeKBvPiiYaY0Fvqz/cBThjvARhprJXQqauO/QHL4rmmm8mzBtc3jVxMGicKSMvbKRKcpE
+        lqdA7HPfAt0eFbfoEOzRQiuI6YJdpBfFckkiV0RrPye2my0g7y9IChlLtTQpi8ziu6wmKRSY/tYk
+        3hmGFur6df4G9GWpCNfOKL5FFDog3hMKSrbrB/1CEffVKWRWWRNRvxQp86K8sKrANuKjWbEcpVff
+        +mSk1ytlgx6bRU7HKCFv13x1xRg2dT5ZyZcV9O41xw5MXUsO7pV4cpvgPkQKT+CJh4Rqy2a1SA05
+        UlTuZ+oihRWI+2x2sDZcpCio5TwHcIoFGewAcgxgbSD2pVmQUkocyqjDGU5Jw9cRoCJpTPYlfVrl
+        E6yIDQy8pZMbf4npmqLbOEh5JybTd2pa1XtuJeA7kcFVcGH8LNh/sf/d7zTc94qfWhqs2ZdgVuCA
+        wa3Tk5TrjwlwsxnBVPBbnO32VifbaIVO4xnKMuiJvpCHnVFTd04rFFKWGJ4BcGgETK+h0njorRLw
+        7LGgt3UibyhlDXgNdRmPCXU1cF5rS+2JewkEgw7dxxAgd4ppIcDpCgYVaQLUx+1fSRvNs7fcr6fK
+        rwHFI1XqET/jhueXkGG3B4/or15yq5Leq078BbkHuHhonufpxLHbfo2/KS3BGHnyHRoT09KPVB8E
+        GM0ztIbJAWxx6uplSD87UKVfj3EMY4ztSP33eGM7ONdf6S6EhECUMH6JO3ToD/PvV/jTjAG2Zz+F
+        ap91+Etq1qbpAhe3ceNXL3nkbEV+5aM5LqyLv8g8vknHXK9Y+KT89TDPp9n3YbhYLPb60O6D9Dbs
+        HHCRAarNqA5RFOkTLmQcJX0Sr7Nb7ODVug51f700kf5UnuAS9Vcd3B54Q4n5Exg3Z58uVYa85M7B
+        SUx7BVI+6n2fhTd7xhGXLniujrSGMc+iJjA+Xh7SZ6s6rFJhGI+mIW8w/oZLD4b5eNQ5OLxGhIlR
+        XEqczUF0SVGZIzYajtu2cY9GpGikL2a4ArfrhBPqxPSO3Yh5Qakm1hv2gqsMuV4kjitLR7jOUDds
+        MrBkNg6vp8kYxSkQcJKezt6/PSz6qMkEs7L0vxAasqgOaOmwrBinONgEdwb2eVjIZOzRoMxa6yez
+        zLPzI7ctLCYblpQ1Ri5ZuibRBCsJL9b9a/Z51d7kkKQJcjp943wh+1xsxw0N1NUABJycj+/ry0Yc
+        oG/54Lx5UdDabC/8qm8NyOKcoA8uximlsVQduDWmlPpKpuurr3aKQnE10PUIV/g6F2PbYlxH9KJ+
+        RXZLaCz4JiCZEbqkEOcnII4HsXu8Edpvt9Cvoxku98xwN/oI8x/fmfsmpRk3o+vmgh92jwKT370W
+        Xeje+n3o16N5zNe7wRrKY3PI9KhoVVdobXPkxTG2I/qzTVDzfn8UD+PIXGRnn1sEKieAwFupKWUq
+        54DAVmhpF/BtlNE93bKcAFY/twk0mUyiMcydgpeOdVPbjER5wQAcQ8jqtCDKBsbNaqfU0uaYBXBF
+        emjgHuFhlMmOpZgeP0ouDlDssUKDc9PaIh0GUW+ByKFw22t5aBPcLCbVifhIZFLgX0sToiNoahc0
+        AjMo2TwoSU2At81tczvuBRvhZkZkDVKAWGiOe8CkrW11PcSFgRh5hdXecKvysFpLHM9lI531/gdM
+        SOurHbEqLC6X695xS+tMN0oRfs4jGPA9Z87fFa1tzzqdkkQ9SeG1c3locZGN0xybaHes59LS9jj5
+        rCbKbgTTBP7hRAs0PpCJVnUhrS2O3CKAkjC3CDlodWYxQDUYbm4RhRkIfw1pCv9nbZ1/cN75VvvO
+        jWMgUxhtgE4PbY6d8jwmcRf31jsL7UPR2jYDzua9Hm5dtHL9Az23DTRDJXjXSr3Ec+s2Ko699CFK
+        yfUnYgX3WfchSamhxRlGsZfxNGbjYWGqtqKOi7SpS7S1CRx5IrMoyArI3NA22AUlnY6IiQvG+mTa
+        KszVkr4GCjmyXRF5I6ni7IiAR/GidaYTNLT15jKfoCEv2mdCuozZnQs8VqaB3PxO9A6z0iTyscYb
+        1YejnLiAPtOhnzNp4oMEjeM968AgAQxu2JGke3IWkIFm3uhkEU7B2RVYwgqbEG0QH5GT8hMed9X9
+        rs5grCEevzY+UT7hqmmnB6Qzzq7SdLSrkWGqsJkoscUpUkrSMUo6vR3j+gvHMWPEg8ucLmf6wjO1
+        EeukAL1zkYuNC6krIBp1RB6OO2uXHumnZadiGnXpvwHUd/Gn9dA6bm/CfSswKDc8wolqhGH1dFMq
+        sTwTZSwsBlBO1dgFTBwHQOALTCBrlu+rk+kxmWwmv4vvqatOFqFA/9136OEsjXookzpMuthrCQIf
+        0ISyqNLUGuAomeGO+L6JiB/qx9bgVe9kwz1e9oL608rNbDhVv+Se+p3QnJxH9uA8JM7CJoeSH8u+
+        wVk6etMaRfgWLJTHvS4I8QnKSV3pJj9gVw4xNfgU1HZ8iPAddj0mo1gefFC36x1hNAS0KfRLEbVo
+        gkuv+aGH+APdIiTcjrCa/uophdjsZ1phnuiPd4gWMxvu16U0PL3khAFN2+5gDSOcycRxnYSVigb2
+        Rhq1pvHwlzvF61QNqnToblGmIwvFEYvCeIcZdnTqj3OyPzDM6pB8M2rzbenkH61OLQ/JrijlTV7p
+        9+VODdYGY0hwH5Tq4X8Bgq3QbXxnRC7d2ESdsxJwlE2T/sJpOtX5uLh3g3sVEBe2HfdtcLsFweuo
+        rGO2BBVGiOMh64hKlVCxxVm8CK5RNVJQoCAfko7kXBRVLqFrtPCJOsInZWrK0nZxMnRdJgKrhJXo
+        Lwr8Fkdo2aI6kpZ7D56NHN090q3oBkS2qdA9+UwKi1uujMI7RaDBlYRGjSO3Ghbg0iUvAaFhtCe3
+        MKgdwShC2nq0zowWAW0aG49x7VRuPJFwf/PxkxI7w//N5052xcsVIKF5do/YIUWzqBhhEHDP1iEx
+        c5ODPzWWNUD1C2RRRTg5Whr3CTW5K9glZ2MmqgKiJKUMSYJ8mg0CswyTzjRQLVTz1gVPIOW/KiLU
+        2kiMVJHhlQV24qBLkJgALslhER0wEwbq7clqieGi0wiNVVVYRH6tqKXCa80a7Y7MbkyFVeDDFS/L
+        p8JWoOgeS7OYMnqumKWGhvO2AqmsCcaQXn8nBc0VZbG2pmlmrwX+IK/48A5WlbyqT/hDYgsMqWZl
+        EF3TgRybSwvsuJTloWn2Y2nMA8EYFHZO7++G4tMZsgpx4Mk9mwzXdmw0A1Ll+L17Fhk3geK9D+N7
+        L5ki3YicX93UBC5tstEn3dwO9B7CJvr4MacUafV4Qs1ajFzIi3bgZxBgwwRnerHLtBu9S90Iq4ca
+        24GMaqvZ0LE/cGO1fq7Dc7nS5chGs18p3smXkeLorPXvVw5L8T2kx/y+ikgjcBEusSVjXtuS+mmr
+        rnSRUzmdPkdVRKk4ZU0oMuYslzjvCZgVndsI+WWAS1Y7dkxIypU7Gx2jnZurw20sOpZCNgd2INGo
+        7AjOxkDzapUsSJgjZIf6C7183ogFtnuM5PKSgPnpOk1vNC3k3hLFbHREzU0hj6l0J++9UUsxmvLR
+        FmNzOO/kIKkU0GQiaJJpftO/VHrYzhWfOKlDDFNmDseXXywss9xMC3jJx/oFUgL73A7AwnCYb3UP
+        UtEUO5KMTuQaH5v02FOX0mi7ZXYqmwObdR/6D/45VrQMadmpP8eaLiEFQt0LLb7n3LmQVrA4jeCU
+        cWaSQJq5KRT1vQBXhGRxoJTsNjrgWJsaUxKZ94m4cgKZT3wSjew3+YGZNvVk/9ne/gsuwvm1D/dl
+        0qFgsCp78K45o2I1pTOmeOgiH0LPHe1fqVBNySuCB/pkR2isu6ZxR2BYTdJoC4rQwD1jLdYgDds/
+        UrO8meyOfedbQrzJgTI0OfWhPw7BYGm74wtIuKzqg2HOSgQk0nEizJzTRg2nLqenw1OTRzfa0WVB
+        ec4oaaXnAzK2wim0FjKyprKMnZ05ha0Y/gB1fSMQTnjIWs32U7mC3jiH9Mc0zZso3E2RKS6EqFzr
+        ay+DKF3ta1HxyMkGa60RfTwoIVbk+OXXeeyrS2MXk+ZDauOIxkMhluKOUuL4QaQth/eJdTpGNauh
+        LfJweAMnDGbmyhwObpxyw0NRgrWeJgLrutroiWtpM1rRcY7w4veeImAbLzXI1aJowRiBl+JmREhU
+        +wpZZvKqtPZr+p+wbg0rfXp8ASFpb4kpK8Qy/nKKnD4v60R3KK6wJprivxYHYMK7AUd2eTnw7dRQ
+        JVqJm/jvU8URXi143yWDIfmxqxwqCO8GY6MJUNCtOyctkW0m4JYw8W6Q83Ip8IOqvIapNo7zIbbu
+        QsNj3QqW5dY2iebHy27eIO76ONJqp9fs2cRhSgc6W55UP35VHSF0q8a7H55ufSTAYDIR5MP1anZ/
+        iTZcMMJtMLZpQ4zTqw+PHNDCZAV8kBSG6ezGxueBHN6o41GUjLFt4TcPjx+OCfdSFNYuC5T30orN
+        SPsSxM9s8MpOcKXfDI4S6ya6KrU9PK1uY9SpYnycLYasgj/ZV2t2oLvSFB65u4mR0rIKaGqrtCnm
+        M/iJOHZtkkIuqYEi1e7pPU0I/qdqOZEtBbPE2SjsRMn34LuhXDHE5abE4W6e4Il+h6gcv5ONFLG6
+        i0XZwCPcW0QsjG4mARe+pXCoi+wh3LYT9Qfkm+O4xyBG/CGnWq6Ky9/SxwX2LiHbxDUZ63z0t5PP
+        c8RWsXVQ5yRF6FpQ7dsjqXt5hwMStauBW8UMqZgiKxy3mITEcJclqwJC9ti1nh8eS/ZksLOWNl01
+        T59U0zqi6C27bgljdzilEurunMsyqy6w8hfuW/fNmllZ4QYWeh8u9/aWFtZmTskVYMPV3mepZii+
+        aW2pi9PZY55sSZPSleFL7ghfQ1bmhGJfiHIzUMhCUJ7/c+sq4rKFjLuVUZuR0guqdksonRnlS5sr
+        SAlOfMZKFfFI87Wjjm15RYsmCc6NZen9sOWS65CNnF9UZOMUYzIyAkUi5SvkweuRO2NZYvys0wP3
+        xJ14AFvnMUpe4aY3wfQCbZBauu3nwYu0DlnZlKk2FQ8lKhNZRDXbUh1xkv1kAkxNRPDS/e7nwZ6p
+        arfPDlVL7kpXIoo0Xav1dzHbEeWkaQLyVB9yw89DKVxGisLeuq5uYT7F5uIf3Ed6foEDQLjpEsWf
+        rAmF9358XelqNNRGBp+fwpSAhY1nBv0Z9HljhUp0M9wBEuHgNVVGQX3KSY9/W9r8ECPo6dc9UCXm
+        M+4B1erQQyHg3ukeygYDzZBvqNvI+pClUx1LlODlGod6MGZxkZCij8sIUb1eugJBC2aPhtuSi6nK
+        Imre4qDtLK7jWFCSSixykTCcvZUvywhuSTGR1zYQi4JNdANqKSx7Rk02ukdwPKN3OdBd4U0mrMw7
+        mmNQqjgQ0w0Fp6FlkCEjLHVUmxvKBCQ2perG2g55i9uW9a+IjayirGjJXWIHd9wcEawRJ47RrJaG
+        RdE8E0N183D1BbpsPxN/lcxmRDPL6Spl44RWemVARqBqIbDaF+1ht4KSVeJvOryQhEfSTaZiIRji
+        YOsKIpm5pJmz32DsTEB1qL/xCYBf2AA12wXRAJU32GtclntgSQzHvPuFD8jOkXuJq151dm7c61s9
+        cqA8P81kYmmhGJ3jWf+bsyCuyOKQMmX/swGgZ8dpV2wH/A+ZmUm8yEaoJW8Oq5tZ+cm2rx6IlYM0
+        Ta7IlufNTYbGU1cWfsHnFDUscMRugqNWRhiURZ36kT7BkTv5hMblYO8RezuV5SvRDUvYB71khowZ
+        XJMkzFXCW52Yl8sm5gHRHkdTyu/B6XtzwPA8mlICD7f8AhDk1BBNRi7A65TQdAXLOs5dK3ZKboUK
+        3y3xMvAK2aU+rVjSdWWMsIq2YYSxKoZz3Q4qjB7fXPoYDTtzCnSuvY3NJHyBV8gd2rT7whkg554a
+        Swu/NSxk8Nu/raPk30QISuzYoAksmW+to2RUZbE9E3TIqiLDpNh0tY4KU4edWu4cO9Shd1tRxx6A
+        fEs53LhrBwEHUySy1ITeU9TS5g9aH68hvYxQvMmG7HXgrrzaYHOE0CGHVgUIgob8RN1bTVjRg741
+        7ixC02H1egR3zlCRHMVpcP4FenkKH74pk8yZ3xVReez4+L9Xh5AS+CGCE+4P69RYK50boUm7d1Mn
+        vzwbK5DkbZapn798vppjeB1lSZf3c/ifFKcMtfY6onbJlT2S9jod/FxhWg2fYKp9syqSWzjjNUtx
+        yxcOTyz/Zc0rHefY2ONwrDOlzoUUZZ/NJ/mYTt85KVLIxLc4sLYse6Tvj0voXr/O2+wogCetG7nX
+        w9MlFSh4fjid4sA1eW0iBW/a8SG8paXaroU9sQPEnPgS4+VgFRvz1g0vEV4OVvimRDkP9ZaZH8IH
+        TWcTTnuAxmViFLWlFVRGtEioJFbAFT6TXuE0tcmnkr2DqwblbZ2xhbStkxW+qtlYb0/P6E8/JmZB
+        mQk3C8s+e4y6DalqKCV8qFEyBBLGe6gJrqASonAGJ/Mj3cMw4kduoouW0OSn2SqZ05jXqqjAX4xY
+        o4gslALG3w8IfBx/SbqpAD/nv/3AH4BbZM2ZtOtsPkY2lfWIiVSAnc3HNy/NSx+yO1hgGVXULHMt
+        tTgs28JqqWx8Fj7No11RMl+VjY9f+2hXSEuEukYkZkJepNLxqyPdqvMxPIvJZSeXlKvmLk5znC1G
+        eGVUcRkvU87FDyru4p3p5wLCOpRKOlqmz9XIm07PBoAn42tYAsuW1fkRTIAmy8qa1qtl4AaI1XQu
+        I8oqZrlxwPiyybID42BnyMrBLIpQow7dzDW7zimLgoLSfKklI+6b63VmzO4wRSrS3K5XwjjFidoB
+        Wz5aQR+6rmxC/X3xxc+LO/NGQJmRXPJH48tEVWSGSevPiyNqHMnyRokjPyau7ON5b5CDyCPPwskG
+        fBD1bpMM3ldwI9IhBKdD3QZFhjYfersRwKEIHfbdoU6evuzyJ1687J97h8YWwZeOYGWc0niTaCwo
+        lcWWTcs4gxHvWkRGaIHNfzRJdcnqU9x9gOf//q/UucDDGt7O+Z6GurGpo5JGaQW5sx9eI35q3dc9
+        o67M+zhD7aHSgVhZos5Or05ud1U0HDXd+UwSLIPMRe4/R2bdrbBeh/KVupSvdCC8qnw1VRyarFgJ
+        7dPDB7xWgKjNki4NS9OUZmpzvp1Gd6XgsDyVmcMwhgG1xPFj72WXWT9F7Ma6PHly10yt/X3Y9r3u
+        690/m+KC+qB3QQ1trR6P5neqdv28xyT323Ubo1JylNlfB935DJlR89F8LPNT8pCdmslSx/azMhOI
+        bPStCgui4bz5P8OOH4UPCyeQIFkjG20c6FM3J/oBEUW6GduX8CDkOjuzjiIyytjWZD/GAyI3wAY5
+        tsFeaFj48k5QKV/fXP1aXj8gQoj2QPPP9XmBOqEOZzku1hzCkY+LFPFdHTUjeqpW2mo+tBxJoQJR
+        OhWZRKEAeUEwN1HIbFG5hQi4AVEmvpEvBHcgC5HaoBcFKHgBaYVkdKGpPsR1q94zmFDa0pkWMKe8
+        evG4m94RtKBTpoI9YhH0sJue+zgkiITCODa9n6FBXXLDbiCM5yOqR4pKgIL+uX3eTf92NihvRwr8
+        WA8ZwgxUEgjPdVibMLLeatRsHBlRYdvVwKxeFUhaKcKUVW9JL9LxoXLkshKxOokqeQ9mWGtMAxzq
+        g2y/TUe3sS5P+Bq3c7/VLUStJgaC20sIlr+hQMBYb6wKQWe7Y6GxXtcv6TbkA1nYvSFBkpImTUiv
+        CpiPYuEcFFIiKU3SxPDK+Bj6iBb1L/lleJBpUQVKJkUBocYIPHJf9MCZB4eCIR/bN5Q8DaC4xs33
+        pkv6LFDGwXW6HQnbgzygcwTCxwX66kTeqyhXdIKgvno2I5gDGbYQGxYUNeKLFuomhoOHsS0kjsSX
+        L2xjZyybSAcvx9DhaBcdTLfHlh2MnA0bhwzpnDq+2yGFqpiQ6gIE3spNh2lOaTXTYRPcSMPhO729
+        u3B/2yK+LALgf+Ziq1YjriAhMzfMSPOD++KWxQhUFFMrzH2Jxl0u0LrwQbkWx9qrSx21obm3jGk9
+        kMmsi8Vsc8w7Dwrr7butF3YP+bMDXEOmUwSZXVGXMEZaCPwRaAbb6o2Owwsn/CubWKhZ9Z35Hb2g
+        3zVlCWsM+Lc0tkZLGZ+6HVzaijk4FHbpJht7Vx5D6cq+qhShER6F+qWNFHYrLnwaewF3Q+3pBxf2
+        kBhltksn/HdTCpe4cknvmOxbeJ5RMEBs8IC8UsZ6lXc41qfvhTmjd3Xoxo5pss8o4dSFvfcP3Gyp
+        T0wJZY+l0RyTqoLzmWmlTuPJgEMWQQqLwhr5ulFxThePYet5qgAIWTVqyUUlDnGqRrTfFR9cwSYN
+        BgFuHKmOpJGdUQWGofLRTDnCi0PjAvi1NCs5u0tnyZFFIRtpxmUnsE0+Fh3IEbDm/hZlkq7oVR3W
+        JgxiEwOp8DEOmSbd4rDUpWmyR2UL09DAMC2YXrCKuYJ+hAsHFc5cwl2HU1mjuO+5j35ZBTsZKicu
+        Y3eixd6HosIdjZeZaY2Lbln/4SjCHeEjDDUbuYGsd2gO3xXNFg4zznrh0hxeNXGwKBwpY69sZIoy
+        kfWp9uuk7VFxiw7BHi20gpgu2EV6USyXJHJFtPbnYLvZAvL+gqSQsVRLk5KzLL7LapJCgelvVTso
+        slSEa2cU3yJxDic9F3otS7brB/1CEffVKWRWWRNRv3TSzYvywqoC8wl680u2WNwik87f0qtvfd53
+        3ThAqivGsKnzyUq+rKBnhBZhSP9tO3ZdSw7ulXhym+A+RApP4InphmrLZrVIDTlSVO5n6iKFFcj1
+        X6uTcS+kKKjlECaAUyzIYGiRYwBrA7EvzYIU1XIoow5nOCUNX0eAiqQx2Zf0aR21nTBl/CWma4pu
+        4yDlnZhM36lpVe+5lYBvYjgsZdgquDB+Fuy/2P/udxrue8VPLQ3W7EswK4hk49bpScr1xwS42Yxg
+        KvgtznZ7q5NtxKXI4UdZBmNZysPOqKk7xyUPAz5HEEgD2e05mF5DpfHQKQN1weA5GkJv60TecAUa
+        8BrqskkX6mrgvNaW2hP3EggGHbqPAXn/8ijA6QoGpE4LDvVx+1fSRvPsLffrqfJrQPFIlXrEzy8h
+        wG4P8HcvwT+PXv4qCD7j2g74EQO0Zt1ZMoUZN+u+6gzzfJp9H4bR5+jLHm58RW3taJpke0id4DYk
+        pVxnofw43Nd/7I2Tyd7nrIO629LXAeDqv6g6WbrY+4xrvOCP/M//VKbixd4CF13ETx6XwPPBJ33j
+        WPg5C3HksZfONJhgf49qZRfQ/h8D7jEqZ1vIPLxxeo2L1xXZpe4Y87tp/KqTx1/y8HN0G8lvOjL0
+        KmwZ5N6Y+iiPTihoTnzcxioZ46B2xoBA2oukS+c0+3RzRJW+VSBIXDTfIlsM+0EJE5SIaWjpR9Pt
+        wfnbh3EX503SsZJRC7ryt7/nMU7QlLtRj2To5+d/+4zbl8991H1coe5j7vxxaeAgTZxBqoxwTeSP
+        6EiT+HHBQALnNTOgOoRwuYOodFE+ePTVbTRTfxtEf1ev5B8w11/++sMjatqbzrPhk788/hv04WGX
+        0mPzx0/V44+HwfNvnj377ttvXgT7j//6deVjbIO6NxeYytskXvDrR0+wb2cT88nX6p+PCOIgAjzL
+        xLgdDbspFMPEEPInj4Wcj7/+AZ/tEbPh2xpB+GWU3U26eIvTQ/EPj/A1lh8enzyWFfhYvXKgjFBT
+        QuohwoxN4VdU/6H0h2GYZaPH6nt5xspdLBaPv1a/UY/18oVNp6nHixiQPmePf+ChZO5IsAPWw8iO
+        7q6iwU8o9FEM6C/P/vqDgrznwNtPaS/eS2jTkB/F2BDHTwbRU5WBnP/6+gn+1y5GmcX4C3KcetE1
+        1iPS4NRyLly5OnGcHVD1oiRxpCUYhML+3rNCKBhBANgyGzAs/u2JmbCv9zBhvbvytCo2Pf7tyeM9
+        4Pc3vs8ICu3x13td2G03vm/Jbkv66sm/PckRkfla0+XJ13tJhl5wsA6//vqf1qKhz82n3VGKyurg
+        FQIGGHS/s4aMUiG4rfNvrF2phCneRhPIFojJfz4exlSU8/H3j589/tfT3z57BjpTt+a/Zd3P4jGu
+        y0G10QyYCWL4Yemn/4pHWVxGlnolZscJ+jcMV71aBqCGP7AWXLFkfvN4+gXMZpA0/zbuaw0tLHo+
+        ihCwZYCiXq9KEoMb/v2XJtC/iMbg6RJHs3qZdDPcPhL7ROlKJqZAhqPedDeh/tfHxAUXG0mkaBav
+        ousn8W3+VOXRNa1Ukk40Apq0hFuJiyCT+G/chHmT/fDoK3ysm5eufCYLr/1O8XVHMxs5v54k+O2z
+        H1SiXhJw3d/eCB61fIjm3/zG4EL4FF/8JfnrXpbfjeI9XNkK39MduulM0kncEf74F6PHmDZEjr9d
+        gRq/X4EYvye0urQ6aMwADITr7RAawLgbP+koGLbYzHSeqo6BDMSNdNkrhOjR3dveE3TGk1MfOC7U
+        7N7okWMe9ygRCrN1Fc3QhYPQb0AkAxPidTmoTi/uR8greA/m6BjJVeJcsvoQOYSDB1WyjmCzT057
+        uNmVxPIEY3/V0VOJ2B98JbOOMvbMdZqT2QALdDTvxd8rFFLtsR9UGxJP8UC/yJ6qOO+aX1lQp5Oe
+        BcQvw+u0dwe708UHHxG8l+EwH48OHv1fEwFPJYTfAQA=
+    headers:
+      Cache-Control:
+      - max-age=1800
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - 'default-src ''self'' ''unsafe-eval'' ''unsafe-inline'' data: blob: archive.org
+        web.archive.org analytics.archive.org pragma.archivelab.org'
+      Content-Type:
+      - text/html
+      Date:
+      - Mon, 19 Oct 2020 08:07:14 GMT
+      Link:
+      - <https://www.fws.gov/birds/>; rel="original", <http://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
+        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.fws.gov/birds/>;
+        rel="timegate", <http://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
+        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <http://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
+        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
+        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <http://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
+        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <http://web.archive.org/web/20201011123440/http://www.fws.gov/birds>;
+        rel="last memento"; datetime="Sun, 11 Oct 2020 12:34:40 GMT"
+      Memento-Datetime:
+      - Fri, 24 Nov 2017 15:13:15 GMT
+      Server:
+      - nginx/1.15.8
+      Server-Timing:
+      - exclusion.robots.policy;dur=0.362760, PetaboxLoader3.datanode;dur=97.814636,
+        PetaboxLoader3.resolve;dur=99.612191, LoadShardBlock;dur=179.963844, exclusion.robots;dur=0.380935,
+        captures_list;dur=230.191686, esindex;dur=0.026291, CDXLines.iter;dur=22.173708,
+        load_resource;dur=65.524959, RedisCDXSource;dur=2.473342
+      Transfer-Encoding:
+      - chunked
+      X-App-Server:
+      - wwwb-app12
+      X-Archive-Orig-Date:
+      - Fri, 24 Nov 2017 15:13:14 GMT
+      X-Archive-Orig-Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Archive-Orig-Transfer-Encoding:
+      - chunked
+      X-Archive-Screenname:
+      - '0'
+      X-Archive-Src:
+      - archiveteam_archivebot_go_20171125060002/nostalgia.esmartkid.com-inf-20171124-135423-93c54-00000.warc.gz
+      X-Cache-Key:
+      - httpweb.archive.org/web/20171124151315id_/https://www.fws.gov/birds/US
+      X-Page-Cache:
+      - MISS
+      X-location:
+      - All
+      X-ts:
+      - '200'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/wayback/tests/test_client.py
+++ b/wayback/tests/test_client.py
@@ -5,7 +5,8 @@ import vcr
 from .._utils import SessionClosedError
 from .._client import (WaybackSession,
                        WaybackClient,
-                       original_url_for_memento)
+                       original_url_for_memento,
+                       memento_url_data)
 from ..exceptions import MementoPlaybackError, RateLimitError, BlockedSiteError
 
 
@@ -195,6 +196,27 @@ def test_get_memento_should_fail_for_non_playbackable_mementos():
         with pytest.raises(MementoPlaybackError):
             client.get_memento(
                 'http://web.archive.org/web/20170929002712id_/https://www.fws.gov/birds/')
+
+
+# @ia_vcr.use_cassette()
+def test_get_memento_target_window():
+    with WaybackClient() as client:
+        response = client.get_memento('http://web.archive.org/web/20171101000000id_/'
+                                      'https://www.fws.gov/birds/',
+                                      exact=False,
+                                      target_window=25 * 24 * 60 * 60)
+        _, memento_time = memento_url_data(response.url)
+        assert memento_time == datetime(2017, 11, 24, 15, 13, 15)
+
+
+# @ia_vcr.use_cassette()
+def test_get_memento_raises_when_memento_is_outside_target_window():
+    with pytest.raises(MementoPlaybackError):
+        with WaybackClient() as client:
+            client.get_memento('http://web.archive.org/web/20171101000000id_/'
+                               'https://www.fws.gov/birds/',
+                               exact=False,
+                               target_window=24 * 60 * 60)
 
 
 @ia_vcr.use_cassette()

--- a/wayback/tests/test_client.py
+++ b/wayback/tests/test_client.py
@@ -198,7 +198,7 @@ def test_get_memento_should_fail_for_non_playbackable_mementos():
                 'http://web.archive.org/web/20170929002712id_/https://www.fws.gov/birds/')
 
 
-# @ia_vcr.use_cassette()
+@ia_vcr.use_cassette()
 def test_get_memento_target_window():
     with WaybackClient() as client:
         response = client.get_memento('http://web.archive.org/web/20171101000000id_/'
@@ -209,7 +209,7 @@ def test_get_memento_target_window():
         assert memento_time == datetime(2017, 11, 24, 15, 13, 15)
 
 
-# @ia_vcr.use_cassette()
+@ia_vcr.use_cassette()
 def test_get_memento_raises_when_memento_is_outside_target_window():
     with pytest.raises(MementoPlaybackError):
         with WaybackClient() as client:


### PR DESCRIPTION
The `target_window` parameter for `get_memento()` is supposed to limit how far off in time from the requested time you can get a memento for when the `exact` parameter is `False`. However, it only works correctly when the target is off by less than a day! (The scenarios we were originally concerned with in EDGI almost invariably were on the scale of a few hours, so I guess that's how this error snuck in. 😬) If you set `exact=True` (the default), this bug wouldn’t be triggered.

We were checking the target offset by the number of seconds, irrespective of the additional number of days involved. We should have been checking by `total_seconds`, which converts the days into seconds and includes them. I’ve also added tests here to make sure this problem doesn’t occur again.

This PR targets the v0.2.x branch; I’ll add a new PR for `main` (which is now for v0.3.x) after this merges.