### PR TITLE
Backport session timeout fix from #68

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -2,6 +2,12 @@
 Release History
 ===============
 
+v0.2.6 (In Development)
+-----------------------
+
+Fix a major bug where a session’s ``timeout`` would not actually be applied to most requests. HUGE thanks to @LionSzl for discovering this issue and addressing it. (`#68 <https://github.com/edgi-govdata-archiving/wayback/pull/68>`_)
+
+
 v0.2.5 (2020-10-19)
 -------------------
 


### PR DESCRIPTION
Backport the fix for the `timeout` bug in #68 to the v0.2.x release line, since it's a pretty critical issue.