### PR TITLE
Add Python 3.9 and 3.10 to the test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              python-version: ["3.6", "3.7", "3.8"]
+              python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
       - lint
       - build
       - docs


### PR DESCRIPTION
There have been some major releases to Python and we haven’t been testing on them!