### PR TITLE
Unpin docs dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,6 @@ commands:
       python-version:
         type: string
     steps:
-      - restore_cache:
-          keys:
-            - cache_v5-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-            - cache_v5-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-
-            - cache_v5-wayback-<< parameters.python-version >>-{{ arch }}-
-
       - run:
           name: Install Dependencies
           command: |
@@ -22,11 +16,6 @@ commands:
             pip install --upgrade pip
             pip install .
             pip install -r requirements-dev.txt  # extra requirements for tests, docs
-
-      - save_cache:
-          key: cache_v5-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-          paths:
-            - ~/venv
 
 jobs:
   test:
@@ -95,11 +84,11 @@ jobs:
   docs:
     working_directory: ~/wayback
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.10
     steps:
       - checkout
       - setup_pip:
-          python-version: "3.8"
+          python-version: "3.10"
       - run:
           name: Build docs
           command: |

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,9 +17,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../..'))
 
 
 # -- General configuration ------------------------------------------------
@@ -81,7 +81,7 @@ release = wayback.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -90,7 +90,7 @@ exclude_patterns = []
 
 # Set up link shortcuts
 extlinks = {
-    'issue': ('https://github.com/edgi-govdata-archiving/wayback/issues/%s', '#'),
+    'issue': ('https://github.com/edgi-govdata-archiving/wayback/issues/%s', 'issue %s'),
 }
 
 # The name of the Pygments (syntax highlighting) style to use.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,11 +7,14 @@ coverage
 flake8
 requests-mock
 pytest
-sphinx ~=3.1.1
+
+# remove pin after https://github.com/readthedocs/sphinx_rtd_theme/issues/1343 closes
+sphinx!=5.2.0.post0
+
 vcrpy
 twine
 # These are dependencies of various sphinx extensions for documentation.
 ipython
-numpydoc ~=1.0.0
-sphinx-copybutton ~=0.2.12
-sphinx_rtd_theme ~=0.5.0
+numpydoc
+sphinx-copybutton
+sphinx_rtd_theme


### PR DESCRIPTION
The sphinx doc build run by CircleCI is currently failing:

```
make: Entering directory '/home/circleci/wayback/docs'
Traceback (most recent call last):
  File "/home/circleci/venv/bin/sphinx-build", line 5, in <module>
    from sphinx.cmd.build import main
  File "/home/circleci/venv/lib/python3.8/site-packages/sphinx/cmd/build.py", line 25, in <module>
    from sphinx.application import Sphinx
  File "/home/circleci/venv/lib/python3.8/site-packages/sphinx/application.py", line 42, in <module>
    from sphinx.registry import SphinxComponentRegistry
  File "/home/circleci/venv/lib/python3.8/site-packages/sphinx/registry.py", line 24, in <module>
    from sphinx.builders import Builder
  File "/home/circleci/venv/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 26, in <module>
    from sphinx.util import import_object, logging, rst, progress_message, status_iterator
  File "/home/circleci/venv/lib/python3.8/site-packages/sphinx/util/rst.py", line 22, in <module>
    from jinja2 import environmentfilter
ImportError: cannot import name 'environmentfilter' from 'jinja2' (/home/circleci/venv/lib/python3.8/site-packages/jinja2/__init__.py)
make: *** [Makefile:20: html] Error 1
make: Leaving directory '/home/circleci/wayback/docs'

Exited with code exit status 2

CircleCI
```

It looks like this might be the result of jinja2 imports being deprecated?

https://github.com/sphinx-doc/sphinx/issues/10291

I tried unpinning all the dependencies, and making a few minor changes to the sphinx config and the docs seem to build fine locally but maybe I'm missing some detail about theme/css?

Unfortunately I did have to tell pip to ignore sphinx 5.2.0.post0 which appears to have a recent bug that hopefully will be fixed shortly:

https://github.com/readthedocs/sphinx_rtd_theme/issues/1343
