### PR TITLE
Repair docs build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,11 +110,11 @@ jobs:
   docs:
     working_directory: ~/wayback
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.8
     steps:
       - checkout
       - setup_pip:
-          python-version: "3.10"
+          python-version: "3.8"
           install-docs: true
       - run:
           name: Build docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,11 +110,11 @@ jobs:
   docs:
     working_directory: ~/wayback
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.10
     steps:
       - checkout
       - setup_pip:
-          python-version: "3.8"
+          python-version: "3.10"
           install-docs: true
       - run:
           name: Build docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,14 @@ commands:
     parameters:
       python-version:
         type: string
+      install-docs:
+        description: Install docs dependencies
+        type: boolean
+        default: false
     steps:
       - restore_cache:
           keys:
+            - cache_v5-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-docs.txt" }}
             - cache_v5-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
             - cache_v5-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-
             - cache_v5-wayback-<< parameters.python-version >>-{{ arch }}-
@@ -21,10 +26,20 @@ commands:
             # Ensure pip is up-to-date
             pip install --upgrade pip
             pip install .
-            pip install -r requirements-dev.txt  # extra requirements for tests, docs
+            pip install -r requirements-dev.txt  # extra requirements for tests
+      
+      # Docs dependencies are only compatible on Python 3.10+, so only install
+      # them on demand.
+      - when:
+          condition: << parameters.install-docs >>
+          steps:
+            - run:
+                command: |
+                  . ~/venv/bin/activate
+                  pip install -r requirements-docs.txt
 
       - save_cache:
-          key: cache_v5-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+          key: cache_v5-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-docs.txt" }}
           paths:
             - ~/venv
 
@@ -95,11 +110,12 @@ jobs:
   docs:
     working_directory: ~/wayback
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.10
     steps:
       - checkout
       - setup_pip:
-          python-version: "3.8"
+          python-version: "3.10"
+          install-docs: true
       - run:
           name: Build docs
           command: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,6 +18,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 build:
+  os: ubuntu-22.04
   tools:
     python: "3.10"
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,6 +18,6 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.10
+  version: 3.8
   install:
     - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -24,4 +24,6 @@ build:
 
 python:
   install:
-    - requirements: "docs/requirements.txt"
+    - method: pip
+      path: "."
+    - requirements: "requirements-docs.txt"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,6 +18,6 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.10
   install:
     - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,10 @@ sphinx:
 formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
+build:
+  tools:
+    python: "3.10"
+
 python:
-  version: 3.8
   install:
-    - requirements: docs/requirements.txt
+    - requirements: "docs/requirements.txt"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019-2021, Environmental Data Governance Initiative (EDGI)
+Copyright (c) 2019-2022, Environmental Data Governance Initiative (EDGI)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,6 @@ Thanks to the following people for their contributions and help on this package!
 License & Copyright
 -------------------
 
-Copyright (C) 2019-2021 Environmental Data and Governance Initiative (EDGI)
+Copyright (C) 2019-2022 Environmental Data and Governance Initiative (EDGI)
 
 This program is free software: you can redistribute it and/or modify it under the terms of the 3-Clause BSD License. See the `LICENSE <https://github.com/edgi-govdata-archiving/wayback/blob/master/LICENSE>`_ file for details.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,0 @@
--r ../requirements.txt
--r ../requirements-docs.txt
-# We need to tell readthedocs to install `wayback` itself as well.
-# Confusingly, we have to specify this directory relative to the repo root
-# rather than relative to the directory where this file resides. That is
-# inconsistent with the lines above...the mysteries of pip!
-./

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 -r ../requirements.txt
--r ../requirements-dev.txt
+-r ../requirements-docs.txt
 # We need to tell readthedocs to install `wayback` itself as well.
 # Confusingly, we have to specify this directory relative to the repo root
 # rather than relative to the directory where this file resides. That is

--- a/docs/source/_static/styles.css
+++ b/docs/source/_static/styles.css
@@ -1,0 +1,8 @@
+/*
+    Sometimes we have long links where the whole URL is in the text. Mark these
+    as OK to break in the middle of words so we don’t wind up with ultra-wide
+    elements that don’t fit in the page.
+*/
+a.reference {
+    word-break: break-word;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,8 +65,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'wayback'
-copyright = '2019, Environmental Data Governance Initiative'
-author = 'Environmental Data Governance Initiative'
+copyright = '2019–2022, Environmental Data & Governance Initiative'
+author = 'Environmental Data & Governance Initiative'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,8 @@ extensions = [
 # Generate the API documentation when building
 autosummary_generate = True
 numpydoc_show_class_members = False
+numpydoc_xref_param_type = True
+numpydoc_xref_ignore = {'type', 'optional', 'default'}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -81,7 +83,7 @@ release = wayback.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -90,7 +92,7 @@ exclude_patterns = []
 
 # Set up link shortcuts
 extlinks = {
-    'issue': ('https://github.com/edgi-govdata-archiving/wayback/issues/%s', '#'),
+    'issue': ('https://github.com/edgi-govdata-archiving/wayback/issues/%s', 'Issue #%s'),
 }
 
 # The name of the Pygments (syntax highlighting) style to use.
@@ -122,7 +124,7 @@ html_static_path = ['_static']
 
 # These paths are either relative to html_static_path
 # or fully qualified paths (eg. https://...)
-html_css_files = []
+html_css_files = ['styles.css']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,14 +4,14 @@ wheel
 check-wheel-contents ~=0.1.0
 codecov
 coverage
-flake8
+flake8 ~=5.0.4
 requests-mock
 pytest
-sphinx ~=3.1.1
+sphinx ~=5.2.2
 vcrpy
 twine
 # These are dependencies of various sphinx extensions for documentation.
-ipython
-numpydoc ~=1.0.0
-sphinx-copybutton ~=0.2.12
-sphinx_rtd_theme ~=0.5.0
+ipython ~=8.5.0
+numpydoc ~=1.3.1
+sphinx-copybutton ~=0.5.0
+sphinx_rtd_theme ~=1.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ coverage
 flake8 ~=5.0.4
 requests-mock
 pytest
-sphinx ~=4.5.0
+sphinx ~=4.3.2
 vcrpy
 twine
 # These are dependencies of various sphinx extensions for documentation.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ sphinx ~=4.5.0
 vcrpy
 twine
 # These are dependencies of various sphinx extensions for documentation.
-ipython ~=7.34.0
+ipython ~=7.16.2
 numpydoc ~=1.3.1
 sphinx-copybutton ~=0.5.0
 sphinx_rtd_theme ~=1.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ coverage
 flake8 ~=5.0.4
 requests-mock
 pytest
-sphinx ~=5.2.2
+sphinx ~=4.5.0
 vcrpy
 twine
 # These are dependencies of various sphinx extensions for documentation.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ sphinx ~=5.2.2
 vcrpy
 twine
 # These are dependencies of various sphinx extensions for documentation.
-ipython ~=8.5.0
+ipython ~=7.34.0
 numpydoc ~=1.3.1
 sphinx-copybutton ~=0.5.0
 sphinx_rtd_theme ~=1.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-# These are required for developing the package (running the tests, building
-# the documentation) but not necessarily required for _using_ it.
+# These are required for developing the package (running the tests, packaging
+# etc.) but not necessarily required for _using_ it.
 wheel
 check-wheel-contents ~=0.1.0
 codecov
@@ -7,11 +7,5 @@ coverage
 flake8 ~=5.0.4
 requests-mock
 pytest
-sphinx ~=4.3.2
 vcrpy
 twine
-# These are dependencies of various sphinx extensions for documentation.
-ipython ~=7.16.2
-numpydoc ~=1.3.1
-sphinx-copybutton ~=0.5.0
-sphinx_rtd_theme ~=1.0.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,8 +2,8 @@
 # there are a variety of compatibility issues with our other dev dependencies
 # on Python versions < 3.10 (which we support), so you have to install them in
 # a separate environment from the other dev dependencies.
-sphinx ~=4.3.2
+sphinx ~=5.2.2
 ipython ~=7.16.2
-numpydoc ~=1.3.1
+numpydoc ~=1.4.0
 sphinx-copybutton ~=0.5.0
 sphinx_rtd_theme ~=1.0.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,9 @@
+# These are required for building documentation. They are separated out because
+# there are a variety of compatibility issues with our other dev dependencies
+# on Python versions < 3.10 (which we support), so you have to install them in
+# a separate environment from the other dev dependencies.
+sphinx ~=4.3.2
+ipython ~=7.16.2
+numpydoc ~=1.3.1
+sphinx-copybutton ~=0.5.0
+sphinx_rtd_theme ~=1.0.0

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -197,9 +197,9 @@ class WaybackSession(_utils.DisableAfterCloseSession, requests.Session):
 
     Parameters
     ----------
-    retries : int, optional
+    retries : int, default: 6
         The maximum number of retries for requests.
-    backoff : int or float, optional
+    backoff : int or float, default: 2
         Number of seconds from which to calculate how long to back off and wait
         when retrying requests. The first retry is always immediate, but
         subsequent retries increase by powers of 2:
@@ -208,8 +208,8 @@ class WaybackSession(_utils.DisableAfterCloseSession, requests.Session):
 
         So if this was `4`, retries would happen after the following delays:
         0 seconds, 4 seconds, 8 seconds, 16 seconds, ...
-    timeout : int or float or tuple of (int or float, int or float), optional
-        A timeout to use for all requests. (Default: ``60``)
+    timeout : int or float or tuple of (int or float, int or float), default: 60
+        A timeout to use for all requests.
         See the Requests docs for more:
         http://docs.python-requests.org/en/master/user/advanced/#timeouts
     user_agent : str, optional
@@ -606,7 +606,7 @@ class WaybackClient(_utils.DepthCountedContext):
             The time at which to retrieve a memento of ``url``. If ``url`` is
             a :class:`wayback.CdxRecord` or full memento URL, this parameter
             can be omitted.
-        mode : wayback.Mode or str, optional
+        mode : wayback.Mode or str, default: wayback.Mode.original
             The playback mode of the memento. This determines whether the
             content of the returned memento is exactly as originally captured
             (the default) or modified in some way. See :class:`wayback.Mode`
@@ -615,29 +615,26 @@ class WaybackClient(_utils.DepthCountedContext):
             For more details, see:
             http://archive-access.sourceforge.net/projects/wayback/administrator_manual.html#Archival_URL_Replay_Mode
 
-            Default: :py:attr:`wayback.Mode.original`
-
-        exact : boolean, optional
+        exact : boolean, default: True
             If false and the requested memento either doesn't exist or can't be
             played back, this returns the closest-in-time memento to the
             requested one, so long as it is within ``target_window``. If there
             was no memento in the target window or if ``exact=True``, then this
             will raise :class:`wayback.exceptions.MementoPlaybackError`.
-            Default: True
         exact_redirects : boolean, optional
             If false and the requested memento is a redirect whose *target*
             doesn't exist or can't be played back, this returns the
             closest-in-time memento to the intended target, so long as it is
             within ``target_window``. If unset, this will be the same as
             ``exact``.
-        target_window : int, optional
+        target_window : int, default: 86400
             If the memento is of a redirect, allow up to this many seconds
             between the capture of the redirect and the capture of the
             redirect's target URL. This window also applies to the first
             memento if ``exact=False`` and the originally
             requested memento was not available.
             Defaults to 86,400 (24 hours).
-        follow_redirects : boolean, optional
+        follow_redirects : boolean, default: True
             If true (the default), ``get_memento`` will follow historical
             redirects to return the content that a web browser would have
             ultimately displayed at the requested URL and time, rather than the
@@ -646,7 +643,6 @@ class WaybackClient(_utils.DepthCountedContext):
             ``http://example.com/b``, then this method returns the memento for
             ``/a`` when ``follow_redirects=False`` and the memento for ``/b``
             when ``follow_redirects=True``.
-            Default: True
 
         Returns
         -------

--- a/wayback/_utils.py
+++ b/wayback/_utils.py
@@ -147,9 +147,9 @@ def rate_limited(calls_per_second=2, group='default'):
 
     Parameters
     ----------
-    calls_per_second : float or int, optional
+    calls_per_second : float or int, default: 2
         Maximum number of calls into this context allowed per second
-    group : string, optional
+    group : string, default: 'default'
         Unique name to scope rate limiting. If two contexts have different
         `group` values, their timings will be tracked separately.
     """


### PR DESCRIPTION
This takes over for #90 and sets appropriate, working constraints on all the dev dependencies involved in building docs (we should really set constraints on *all* the dev dependencies, but this is at least an improvement). I should get the docs building correctly again, and also takes advantage of new features in the docs tools we use (like a new recommended syntax for defaults in numpydoc!).