### PR TITLE
Minor performance improvement to timestamp fix

### DIFF
--- a/wayback/_utils.py
+++ b/wayback/_utils.py
@@ -71,19 +71,16 @@ def parse_timestamp(time_string):
     # see the raw data so this is as close as we can get.
     #
     # The issue seems to be limited to some crawls in the year 2000.
-    timestamp_chars = list(time_string)
-    if timestamp_chars[4:6] == ['0', '0']:
+    if time_string[5] == '0' and time_string[4] == '0':
         logger.warning("found invalid timestamp with month 00: %s", time_string)
-        del timestamp_chars[4:6]
-        timestamp_chars.extend(['0', '0'])
-    elif timestamp_chars[6:8] == ['0', '0']:
+        time_string = f'{time_string[0:4]}{time_string[6:]}00'
+    elif time_string[7] == '0' and time_string[6] == '0':
         logger.warning("found invalid timestamp with day 00: %s", time_string)
-        del timestamp_chars[6:8]
-        timestamp_chars.extend(['0', '0'])
+        time_string = f'{time_string[0:6]}{time_string[8:]}00'
 
     # Parse the cleaned-up result.
     return (datetime
-            .strptime(''.join(timestamp_chars), URL_DATE_FORMAT)
+            .strptime(time_string, URL_DATE_FORMAT)
             .replace(tzinfo=timezone.utc))
 
 


### PR DESCRIPTION
I had wondered before about the performance implications of making an extra list when parsing timestamps, and @edsu’s recent patch in #89 got me to take a look.

This is a minor 5-6% performance improvement, which may be worthwhile if you are iterating through extremely large result sets. Part of this is not allocating a few new lists, and part is checking the least significant digit first, since there are relatively few valid months/days where the least significant digit is `0`.

Tested against a set of 1,000,000 randomly generated timestamps:

```py
from random import randint

def make_random_timestamp():
    year = randint(1995, 2022)
    month = randint(1, 12)
    day = randint(1, 28)
    hour = randint(0, 23)
    minute = randint(0, 59)
    second = randint(0, 59)
    shuffle = randint(0, 3)
    if shuffle == 0:
        # "00" before month
        return f'{year}00{month:0>2d}{day:0>2d}{hour:0>2d}{minute:0>2d}'
    elif shuffle == 1:
        # "00" before day
        return f'{year}{month:0>2d}00{day:0>2d}{hour:0>2d}{minute:0>2d}'
    else:
        # Normal, valid timestamp
        return f'{year}{month:0>2d}{day:0>2d}{hour:0>2d}{minute:0>2d}{second:0>2d}'

stamps = [make_random_timestamp() for i in range(1_000_000)]
```