### PR TITLE
Use HTTPS for all archive.org URLs

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -5,7 +5,10 @@ Release History
 In Development
 --------------
 
-**Breaking Change:** This release includes a significant overhaul of parameters for :meth:`wayback.WaybackClient.search`.
+Breaking Changes
+^^^^^^^^^^^^^^^^
+
+This release includes a significant overhaul of parameters for :meth:`wayback.WaybackClient.search`.
 
 - The ``limit`` parameter now has a default value. There are very few cases where you should not set a ``limit`` (not doing so will typically break pagination), and there is now a default value to help prevent mistakes. We’ve also added documentation to explain how and when to adjust this value, since it is pretty complex. (:issue:`65`)
 
@@ -20,6 +23,12 @@ In Development
   - ``resolveRevisits`` → ``resolve_revisits``
 
 - Expanded the method documentation to explain things in more depth and link to more external references.
+
+
+Maintenance
+^^^^^^^^^^^
+
+All API requests to archive.org now use HTTPS instead of HTTP. Thanks to @sundhaug92 for calling this out.
 
 
 v0.3.3 (2022-09-30)

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -28,7 +28,7 @@ This release includes a significant overhaul of parameters for :meth:`wayback.Wa
 Maintenance
 ^^^^^^^^^^^
 
-All API requests to archive.org now use HTTPS instead of HTTP. Thanks to @sundhaug92 for calling this out.
+All API requests to archive.org now use HTTPS instead of HTTP. Thanks to @sundhaug92 for calling this out. (:issue:`81`)
 
 
 v0.3.3 (2022-09-30)

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -45,7 +45,7 @@ from .exceptions import (WaybackException,
 
 logger = logging.getLogger(__name__)
 
-CDX_SEARCH_URL = 'http://web.archive.org/cdx/search/cdx'
+CDX_SEARCH_URL = 'https://web.archive.org/cdx/search/cdx'
 # This /web/timemap URL has newer features, but has other bugs and doesn't
 # support some features, like resume keys (for paging). It ignores robots.txt,
 # while /cdx/search obeys robots.txt (for now). It also has different/extra
@@ -53,9 +53,9 @@ CDX_SEARCH_URL = 'http://web.archive.org/cdx/search/cdx'
 # https://github.com/internetarchive/wayback/blob/bd205b9b26664a6e2ea3c0c2a8948f0dc6ff4519/wayback-cdx-server/src/main/java/org/archive/cdxserver/format/CDX11Format.java#L13-L17  # noqa
 # NOTE: the `length` and `robotflags` fields appear to always be empty
 # TODO: support new/upcoming CDX API
-# CDX_SEARCH_URL = 'http://web.archive.org/web/timemap/cdx'
+# CDX_SEARCH_URL = 'https://web.archive.org/web/timemap/cdx'
 
-ARCHIVE_URL_TEMPLATE = 'http://web.archive.org/web/{timestamp}{mode}/{url}'
+ARCHIVE_URL_TEMPLATE = 'https://web.archive.org/web/{timestamp}{mode}/{url}'
 REDUNDANT_HTTP_PORT = re.compile(r'^(http://[^:/]+):80(.*)$')
 REDUNDANT_HTTPS_PORT = re.compile(r'^(https://[^:/]+):443(.*)$')
 DATA_URL_START = re.compile(r'data:[\w]+/[\w]+;base64')
@@ -77,7 +77,7 @@ class Mode(Enum):
     these values to determine how the response body should be formatted.
 
     For more details, see:
-    http://archive-access.sourceforge.net/projects/wayback/administrator_manual.html#Archival_URL_Replay_Mode
+    https://archive-access.sourceforge.net/projects/wayback/administrator_manual.html#Archival_URL_Replay_Mode
 
     Examples
     --------
@@ -211,7 +211,7 @@ class WaybackSession(_utils.DisableAfterCloseSession, requests.Session):
     timeout : int or float or tuple of (int or float, int or float), default: 60
         A timeout to use for all requests.
         See the Requests docs for more:
-        http://docs.python-requests.org/en/master/user/advanced/#timeouts
+        https://docs.python-requests.org/en/master/user/advanced/#timeouts
     user_agent : str, optional
         A custom user-agent string to use in all requests. Defaults to:
         `wayback/{version} (+https://github.com/edgi-govdata-archiving/wayback)`
@@ -632,7 +632,7 @@ class WaybackClient(_utils.DepthCountedContext):
             - A ``CdxRecord`` retrieved from
               :meth:`wayback.WaybackClient.search`.
             - A URL of the memento in Wayback, e.g.
-              ``http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/``
+              ``https://web.archive.org/web/20180816111911id_/http://www.noaa.gov/``
 
         datetime : datetime.datetime or datetime.date or str, optional
             The time at which to retrieve a memento of ``url``. If ``url`` is
@@ -645,7 +645,7 @@ class WaybackClient(_utils.DepthCountedContext):
             for a description of possible values.
 
             For more details, see:
-            http://archive-access.sourceforge.net/projects/wayback/administrator_manual.html#Archival_URL_Replay_Mode
+            https://archive-access.sourceforge.net/projects/wayback/administrator_manual.html#Archival_URL_Replay_Mode
 
         exact : boolean, default: True
             If false and the requested memento either doesn't exist or can't be

--- a/wayback/_models.py
+++ b/wayback/_models.py
@@ -63,14 +63,14 @@ And these attributes are synthesized from the information provided by CDX.
 .. py:attribute:: raw_url
 
    The URL to the raw captured content, such as
-   :data:`'http://web.archive.org/web/19961231235847id_/http://www.nasa.gov/'`.
+   :data:`'https://web.archive.org/web/19961231235847id_/http://www.nasa.gov/'`.
 
 .. py:attribute:: view_url
 
    The URL to the public view on Wayback Machine. In this view, the links and
    some subresources in the document are rewritten to point to Wayback URLs.
    There is also a navigation panel around the content. Example URL:
-   :data:`'http://web.archive.org/web/19961231235847/http://www.nasa.gov/'`.
+   :data:`'https://web.archive.org/web/19961231235847/http://www.nasa.gov/'`.
 """
 
 
@@ -124,7 +124,7 @@ class Memento:
         List of all URLs redirects followed in order to produce this memento.
         These are "memento URLs" -- that is, they are absolute URLs to the
         Wayback machine like
-        ``http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/``,
+        ``https://web.archive.org/web/20180816111911id_/http://www.noaa.gov/``,
         rather than URLs of captured redirects, like ``http://www.noaa.gov``.
         Many of the URLs in this list do not represent actual mementos.
 
@@ -153,7 +153,7 @@ class Memento:
         :type: str
 
         The URL at which the memento was fetched from the Wayback Machine, e.g.
-        ``http://web.archive.org/web/20180816111911id_/http://www.noaa.gov/``.
+        ``https://web.archive.org/web/20180816111911id_/http://www.noaa.gov/``.
 
     .. py:attribute:: ok
         :type: bool
@@ -252,7 +252,7 @@ class Memento:
         self.close()
 
     @classmethod
-    def parse_memento_headers(cls, raw_headers, url='http://web.archive.org/'):
+    def parse_memento_headers(cls, raw_headers, url='https://web.archive.org/'):
         """
         Extract historical headers from the Memento HTTP response's headers.
 

--- a/wayback/_utils.py
+++ b/wayback/_utils.py
@@ -142,7 +142,7 @@ def memento_url_data(memento_url):
     --------
     Extract original URL, time and mode.
 
-    >>> url = ('http://web.archive.org/web/20170813195036id_/'
+    >>> url = ('https://web.archive.org/web/20170813195036id_/'
     ...        'https://arpa-e.energy.gov/?q=engage/events-workshops')
     >>> memento_url_data(url)
     ('https://arpa-e.energy.gov/?q=engage/events-workshops',

--- a/wayback/tests/cassettes/test_get_memento
+++ b/wayback/tests/cassettes/test_get_memento
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - edgi.web_monitoring.WaybackClient/0.2.0a1.post0.dev0+g800608f
     method: GET
-    uri: http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+    uri: https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
   response:
     body:
       string: !!binary |
@@ -455,13 +455,13 @@ interactions:
       Date:
       - Mon, 18 Nov 2019 17:21:23 GMT
       Link:
-      - <https://www.fws.gov/birds/>; rel="original", <http://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.fws.gov/birds/>;
-        rel="timegate", <http://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
-        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <http://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
-        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
-        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <http://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
-        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <http://web.archive.org/web/20190928223117/https://www.fws.gov/birds/>;
+      - <https://www.fws.gov/birds/>; rel="original", <https://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.fws.gov/birds/>;
+        rel="timegate", <https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
+        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <https://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
+        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
+        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <https://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
+        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <https://web.archive.org/web/20190928223117/https://www.fws.gov/birds/>;
         rel="last memento"; datetime="Sat, 28 Sep 2019 22:31:17 GMT"
       Memento-Datetime:
       - Fri, 24 Nov 2017 15:13:15 GMT

--- a/wayback/tests/cassettes/test_get_memento_follow_redirects_does_not_follow_historical_redirects
+++ b/wayback/tests/cassettes/test_get_memento_follow_redirects_does_not_follow_historical_redirects
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post5.dev0+g4e200c6 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20200201020357id_/http://epa.gov/climatechange
+    uri: https://web.archive.org/web/20200201020357id_/http://epa.gov/climatechange
   response:
     body:
       string: ''
@@ -21,7 +21,7 @@ interactions:
       Date:
       - Mon, 21 Sep 2020 07:37:54 GMT
       Location:
-      - http://web.archive.org/web/20200201023757id_/https://www.epa.gov/climatechange
+      - https://web.archive.org/web/20200201023757id_/https://www.epa.gov/climatechange
       Server:
       - nginx/1.15.8
       Server-Timing:
@@ -52,7 +52,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post5.dev0+g4e200c6 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20200201023757id_/https://www.epa.gov/climatechange
+    uri: https://web.archive.org/web/20200201023757id_/https://www.epa.gov/climatechange
   response:
     body:
       string: '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
@@ -83,16 +83,16 @@ interactions:
       Date:
       - Mon, 21 Sep 2020 07:37:54 GMT
       Link:
-      - <https://www.epa.gov/climatechange>; rel="original", <http://web.archive.org/web/timemap/link/https://www.epa.gov/climatechange>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.epa.gov/climatechange>;
-        rel="timegate", <http://web.archive.org/web/20061007193932/http://www.epa.gov/climatechange>;
-        rel="first memento"; datetime="Sat, 07 Oct 2006 19:39:32 GMT", <http://web.archive.org/web/20200201020358/https://epa.gov/climatechange>;
-        rel="prev memento"; datetime="Sat, 01 Feb 2020 02:03:58 GMT", <http://web.archive.org/web/20200201023757/https://www.epa.gov/climatechange>;
-        rel="memento"; datetime="Sat, 01 Feb 2020 02:37:57 GMT", <http://web.archive.org/web/20200201024403/http://www.epa.gov/climatechange/>;
-        rel="next memento"; datetime="Sat, 01 Feb 2020 02:44:03 GMT", <http://web.archive.org/web/20200918065453/https://www.epa.gov/climatechange>;
+      - <https://www.epa.gov/climatechange>; rel="original", <https://web.archive.org/web/timemap/link/https://www.epa.gov/climatechange>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.epa.gov/climatechange>;
+        rel="timegate", <https://web.archive.org/web/20061007193932/http://www.epa.gov/climatechange>;
+        rel="first memento"; datetime="Sat, 07 Oct 2006 19:39:32 GMT", <https://web.archive.org/web/20200201020358/https://epa.gov/climatechange>;
+        rel="prev memento"; datetime="Sat, 01 Feb 2020 02:03:58 GMT", <https://web.archive.org/web/20200201023757/https://www.epa.gov/climatechange>;
+        rel="memento"; datetime="Sat, 01 Feb 2020 02:37:57 GMT", <https://web.archive.org/web/20200201024403/http://www.epa.gov/climatechange/>;
+        rel="next memento"; datetime="Sat, 01 Feb 2020 02:44:03 GMT", <https://web.archive.org/web/20200918065453/https://www.epa.gov/climatechange>;
         rel="last memento"; datetime="Fri, 18 Sep 2020 06:54:53 GMT"
       Location:
-      - http://web.archive.org/web/20200201023757id_/https://www.epa.gov/sites/production/files/signpost/cc.html
+      - https://web.archive.org/web/20200201023757id_/https://www.epa.gov/sites/production/files/signpost/cc.html
       Memento-Datetime:
       - Sat, 01 Feb 2020 02:37:57 GMT
       Server:

--- a/wayback/tests/cassettes/test_get_memento_follows_historical_redirects
+++ b/wayback/tests/cassettes/test_get_memento_follows_historical_redirects
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post8.dev0+g4902fb0 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20200201020357id_/http://epa.gov/climatechange
+    uri: https://web.archive.org/web/20200201020357id_/http://epa.gov/climatechange
   response:
     body:
       string: ''
@@ -21,7 +21,7 @@ interactions:
       Date:
       - Mon, 21 Sep 2020 07:11:34 GMT
       Location:
-      - http://web.archive.org/web/20200201023757id_/https://www.epa.gov/climatechange
+      - https://web.archive.org/web/20200201023757id_/https://www.epa.gov/climatechange
       Server:
       - nginx/1.15.8
       Server-Timing:
@@ -52,7 +52,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post8.dev0+g4902fb0 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20200201023757id_/https://www.epa.gov/climatechange
+    uri: https://web.archive.org/web/20200201023757id_/https://www.epa.gov/climatechange
   response:
     body:
       string: '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
@@ -83,16 +83,16 @@ interactions:
       Date:
       - Mon, 21 Sep 2020 07:11:35 GMT
       Link:
-      - <https://www.epa.gov/climatechange>; rel="original", <http://web.archive.org/web/timemap/link/https://www.epa.gov/climatechange>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.epa.gov/climatechange>;
-        rel="timegate", <http://web.archive.org/web/20061007193932/http://www.epa.gov/climatechange>;
-        rel="first memento"; datetime="Sat, 07 Oct 2006 19:39:32 GMT", <http://web.archive.org/web/20200201020358/https://epa.gov/climatechange>;
-        rel="prev memento"; datetime="Sat, 01 Feb 2020 02:03:58 GMT", <http://web.archive.org/web/20200201023757/https://www.epa.gov/climatechange>;
-        rel="memento"; datetime="Sat, 01 Feb 2020 02:37:57 GMT", <http://web.archive.org/web/20200201024403/http://www.epa.gov/climatechange/>;
-        rel="next memento"; datetime="Sat, 01 Feb 2020 02:44:03 GMT", <http://web.archive.org/web/20200918065453/https://www.epa.gov/climatechange>;
+      - <https://www.epa.gov/climatechange>; rel="original", <https://web.archive.org/web/timemap/link/https://www.epa.gov/climatechange>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.epa.gov/climatechange>;
+        rel="timegate", <https://web.archive.org/web/20061007193932/http://www.epa.gov/climatechange>;
+        rel="first memento"; datetime="Sat, 07 Oct 2006 19:39:32 GMT", <https://web.archive.org/web/20200201020358/https://epa.gov/climatechange>;
+        rel="prev memento"; datetime="Sat, 01 Feb 2020 02:03:58 GMT", <https://web.archive.org/web/20200201023757/https://www.epa.gov/climatechange>;
+        rel="memento"; datetime="Sat, 01 Feb 2020 02:37:57 GMT", <https://web.archive.org/web/20200201024403/http://www.epa.gov/climatechange/>;
+        rel="next memento"; datetime="Sat, 01 Feb 2020 02:44:03 GMT", <https://web.archive.org/web/20200918065453/https://www.epa.gov/climatechange>;
         rel="last memento"; datetime="Fri, 18 Sep 2020 06:54:53 GMT"
       Location:
-      - http://web.archive.org/web/20200201023757id_/https://www.epa.gov/sites/production/files/signpost/cc.html
+      - https://web.archive.org/web/20200201023757id_/https://www.epa.gov/sites/production/files/signpost/cc.html
       Memento-Datetime:
       - Sat, 01 Feb 2020 02:37:57 GMT
       Server:
@@ -143,7 +143,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post8.dev0+g4902fb0 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20200201023757id_/https://www.epa.gov/sites/production/files/signpost/cc.html
+    uri: https://web.archive.org/web/20200201023757id_/https://www.epa.gov/sites/production/files/signpost/cc.html
   response:
     body:
       string: ''
@@ -157,7 +157,7 @@ interactions:
       Date:
       - Mon, 21 Sep 2020 07:11:37 GMT
       Location:
-      - http://web.archive.org/web/20200201024405id_/https://www.epa.gov/sites/production/files/signpost/cc.html
+      - https://web.archive.org/web/20200201024405id_/https://www.epa.gov/sites/production/files/signpost/cc.html
       Server:
       - nginx/1.15.8
       Server-Timing:
@@ -187,7 +187,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post8.dev0+g4902fb0 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20200201024405id_/https://www.epa.gov/sites/production/files/signpost/cc.html
+    uri: https://web.archive.org/web/20200201024405id_/https://www.epa.gov/sites/production/files/signpost/cc.html
   response:
     body:
       string: !!binary |
@@ -285,13 +285,13 @@ interactions:
       - Mon, 21 Sep 2020 07:11:41 GMT
       Link:
       - <https://www.epa.gov/sites/production/files/signpost/cc.html>; rel="original",
-        <http://web.archive.org/web/timemap/link/https://www.epa.gov/sites/production/files/signpost/cc.html>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.epa.gov/sites/production/files/signpost/cc.html>;
-        rel="timegate", <http://web.archive.org/web/20170428232846/https://www.epa.gov/sites/production/files/signpost/cc.html>;
-        rel="first memento"; datetime="Fri, 28 Apr 2017 23:28:46 GMT", <http://web.archive.org/web/20200131034551/https://www.epa.gov/sites/production/files/signpost/cc.html>;
-        rel="prev memento"; datetime="Fri, 31 Jan 2020 03:45:51 GMT", <http://web.archive.org/web/20200201024405/https://www.epa.gov/sites/production/files/signpost/cc.html>;
-        rel="memento"; datetime="Sat, 01 Feb 2020 02:44:05 GMT", <http://web.archive.org/web/20200201030423/https://www.epa.gov/sites/production/files/signpost/cc.html>;
-        rel="next memento"; datetime="Sat, 01 Feb 2020 03:04:23 GMT", <http://web.archive.org/web/20200918081202/https://www.epa.gov/sites/production/files/signpost/cc.html>;
+        <https://web.archive.org/web/timemap/link/https://www.epa.gov/sites/production/files/signpost/cc.html>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.epa.gov/sites/production/files/signpost/cc.html>;
+        rel="timegate", <https://web.archive.org/web/20170428232846/https://www.epa.gov/sites/production/files/signpost/cc.html>;
+        rel="first memento"; datetime="Fri, 28 Apr 2017 23:28:46 GMT", <https://web.archive.org/web/20200131034551/https://www.epa.gov/sites/production/files/signpost/cc.html>;
+        rel="prev memento"; datetime="Fri, 31 Jan 2020 03:45:51 GMT", <https://web.archive.org/web/20200201024405/https://www.epa.gov/sites/production/files/signpost/cc.html>;
+        rel="memento"; datetime="Sat, 01 Feb 2020 02:44:05 GMT", <https://web.archive.org/web/20200201030423/https://www.epa.gov/sites/production/files/signpost/cc.html>;
+        rel="next memento"; datetime="Sat, 01 Feb 2020 03:04:23 GMT", <https://web.archive.org/web/20200918081202/https://www.epa.gov/sites/production/files/signpost/cc.html>;
         rel="last memento"; datetime="Fri, 18 Sep 2020 08:12:02 GMT"
       Memento-Datetime:
       - Sat, 01 Feb 2020 02:44:05 GMT

--- a/wayback/tests/cassettes/test_get_memento_handles_non_utc_datetime
+++ b/wayback/tests/cassettes/test_get_memento_handles_non_utc_datetime
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post17.dev0+g64f9364 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+    uri: https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
   response:
     body:
       string: !!binary |
@@ -455,13 +455,13 @@ interactions:
       Date:
       - Thu, 01 Oct 2020 01:55:51 GMT
       Link:
-      - <https://www.fws.gov/birds/>; rel="original", <http://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.fws.gov/birds/>;
-        rel="timegate", <http://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
-        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <http://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
-        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
-        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <http://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
-        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <http://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
+      - <https://www.fws.gov/birds/>; rel="original", <https://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.fws.gov/birds/>;
+        rel="timegate", <https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
+        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <https://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
+        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
+        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <https://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
+        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <https://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
         rel="last memento"; datetime="Sun, 13 Sep 2020 10:22:19 GMT"
       Memento-Datetime:
       - Fri, 24 Nov 2017 15:13:15 GMT

--- a/wayback/tests/cassettes/test_get_memento_raises_blocked_error
+++ b/wayback/tests/cassettes/test_get_memento_raises_blocked_error
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.2.3.post9.dev0+g188aa1f (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20170929002712id_/https://nationalpost.com/health/
+    uri: https://web.archive.org/web/20170929002712id_/https://nationalpost.com/health/
   response:
     body:
       string: !!binary |

--- a/wayback/tests/cassettes/test_get_memento_raises_for_mementos_that_redirect_in_a_loop
+++ b/wayback/tests/cassettes/test_get_memento_raises_for_mementos_that_redirect_in_a_loop
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post15.dev0+g11b25c8 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20200925075402id_/https://link.springer.com/article/10.1007/s00382-012-1331-2
+    uri: https://web.archive.org/web/20200925075402id_/https://link.springer.com/article/10.1007/s00382-012-1331-2
   response:
     body:
       string: ''
@@ -23,16 +23,16 @@ interactions:
       - Thu, 01 Oct 2020 01:30:30 GMT
       Link:
       - <https://link.springer.com/article/10.1007/s00382-012-1331-2>; rel="original",
-        <http://web.archive.org/web/timemap/link/https://link.springer.com/article/10.1007/s00382-012-1331-2>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://link.springer.com/article/10.1007/s00382-012-1331-2>;
-        rel="timegate", <http://web.archive.org/web/20160410042521/http://link.springer.com:80/article/10.1007/s00382-012-1331-2>;
-        rel="first memento"; datetime="Sun, 10 Apr 2016 04:25:21 GMT", <http://web.archive.org/web/20200925075359/http://link.springer.com/article/10.1007/s00382-012-1331-2>;
-        rel="prev memento"; datetime="Fri, 25 Sep 2020 07:53:59 GMT", <http://web.archive.org/web/20200925075402/https://link.springer.com/article/10.1007/s00382-012-1331-2>;
-        rel="memento"; datetime="Fri, 25 Sep 2020 07:54:02 GMT", <http://web.archive.org/web/20200925075440/https://link.springer.com/article/10.1007/s00382-012-1331-2>;
-        rel="next memento"; datetime="Fri, 25 Sep 2020 07:54:40 GMT", <http://web.archive.org/web/20200927084438/https://link.springer.com/article/10.1007/s00382-012-1331-2>;
+        <https://web.archive.org/web/timemap/link/https://link.springer.com/article/10.1007/s00382-012-1331-2>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://link.springer.com/article/10.1007/s00382-012-1331-2>;
+        rel="timegate", <https://web.archive.org/web/20160410042521/http://link.springer.com:80/article/10.1007/s00382-012-1331-2>;
+        rel="first memento"; datetime="Sun, 10 Apr 2016 04:25:21 GMT", <https://web.archive.org/web/20200925075359/http://link.springer.com/article/10.1007/s00382-012-1331-2>;
+        rel="prev memento"; datetime="Fri, 25 Sep 2020 07:53:59 GMT", <https://web.archive.org/web/20200925075402/https://link.springer.com/article/10.1007/s00382-012-1331-2>;
+        rel="memento"; datetime="Fri, 25 Sep 2020 07:54:02 GMT", <https://web.archive.org/web/20200925075440/https://link.springer.com/article/10.1007/s00382-012-1331-2>;
+        rel="next memento"; datetime="Fri, 25 Sep 2020 07:54:40 GMT", <https://web.archive.org/web/20200927084438/https://link.springer.com/article/10.1007/s00382-012-1331-2>;
         rel="last memento"; datetime="Sun, 27 Sep 2020 08:44:38 GMT"
       Location:
-      - http://web.archive.org/web/20200925075402id_/https://idp.springer.com/authorize?response_type=cookie&client_id=springerlink&redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2
+      - https://web.archive.org/web/20200925075402id_/https://idp.springer.com/authorize?response_type=cookie&client_id=springerlink&redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2
       Memento-Datetime:
       - Fri, 25 Sep 2020 07:54:02 GMT
       Server:
@@ -120,7 +120,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post15.dev0+g11b25c8 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20200925075402id_/https://idp.springer.com/authorize?response_type=cookie&client_id=springerlink&redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2
+    uri: https://web.archive.org/web/20200925075402id_/https://idp.springer.com/authorize?response_type=cookie&client_id=springerlink&redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2
   response:
     body:
       string: ''
@@ -134,7 +134,7 @@ interactions:
       Date:
       - Thu, 01 Oct 2020 01:30:30 GMT
       Location:
-      - http://web.archive.org/web/20200925075411id_/https://idp.springer.com/authorize?response_type=cookie&client_id=springerlink&redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2
+      - https://web.archive.org/web/20200925075411id_/https://idp.springer.com/authorize?response_type=cookie&client_id=springerlink&redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2
       Server:
       - nginx/1.15.8
       Server-Timing:
@@ -166,7 +166,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post15.dev0+g11b25c8 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20200925075411id_/https://idp.springer.com/authorize?response_type=cookie&client_id=springerlink&redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2
+    uri: https://web.archive.org/web/20200925075411id_/https://idp.springer.com/authorize?response_type=cookie&client_id=springerlink&redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2
   response:
     body:
       string: ''
@@ -182,16 +182,16 @@ interactions:
       - Thu, 01 Oct 2020 01:30:31 GMT
       Link:
       - <https://idp.springer.com/authorize?response_type=cookie&amp;client_id=springerlink&amp;redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2>;
-        rel="original", <http://web.archive.org/web/timemap/link/https://idp.springer.com/authorize?response_type=cookie&amp;client_id=springerlink&amp;redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://idp.springer.com/authorize?response_type=cookie&amp;client_id=springerlink&amp;redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2>;
-        rel="timegate", <http://web.archive.org/web/20200611102358/https://idp.springer.com/authorize?response_type=cookie&amp;client_id=springerlink&amp;redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2>;
-        rel="first memento"; datetime="Thu, 11 Jun 2020 10:23:58 GMT", <http://web.archive.org/web/20200924070527/https://idp.springer.com/authorize?response_type=cookie&amp;client_id=springerlink&amp;redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2>;
-        rel="prev memento"; datetime="Thu, 24 Sep 2020 07:05:27 GMT", <http://web.archive.org/web/20200925075411/https://idp.springer.com/authorize?response_type=cookie&amp;client_id=springerlink&amp;redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2>;
-        rel="memento"; datetime="Fri, 25 Sep 2020 07:54:11 GMT", <http://web.archive.org/web/20200926080807/https://idp.springer.com/authorize?response_type=cookie&amp;client_id=springerlink&amp;redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2>;
-        rel="next memento"; datetime="Sat, 26 Sep 2020 08:08:07 GMT", <http://web.archive.org/web/20200927084407/https://idp.springer.com/authorize?response_type=cookie&amp;client_id=springerlink&amp;redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2>;
+        rel="original", <https://web.archive.org/web/timemap/link/https://idp.springer.com/authorize?response_type=cookie&amp;client_id=springerlink&amp;redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://idp.springer.com/authorize?response_type=cookie&amp;client_id=springerlink&amp;redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2>;
+        rel="timegate", <https://web.archive.org/web/20200611102358/https://idp.springer.com/authorize?response_type=cookie&amp;client_id=springerlink&amp;redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2>;
+        rel="first memento"; datetime="Thu, 11 Jun 2020 10:23:58 GMT", <https://web.archive.org/web/20200924070527/https://idp.springer.com/authorize?response_type=cookie&amp;client_id=springerlink&amp;redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2>;
+        rel="prev memento"; datetime="Thu, 24 Sep 2020 07:05:27 GMT", <https://web.archive.org/web/20200925075411/https://idp.springer.com/authorize?response_type=cookie&amp;client_id=springerlink&amp;redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2>;
+        rel="memento"; datetime="Fri, 25 Sep 2020 07:54:11 GMT", <https://web.archive.org/web/20200926080807/https://idp.springer.com/authorize?response_type=cookie&amp;client_id=springerlink&amp;redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2>;
+        rel="next memento"; datetime="Sat, 26 Sep 2020 08:08:07 GMT", <https://web.archive.org/web/20200927084407/https://idp.springer.com/authorize?response_type=cookie&amp;client_id=springerlink&amp;redirect_uri=https://link.springer.com/article/10.1007/s00382-012-1331-2>;
         rel="last memento"; datetime="Sun, 27 Sep 2020 08:44:07 GMT"
       Location:
-      - http://web.archive.org/web/20200925075411id_/https://link.springer.com/article/10.1007/s00382-012-1331-2
+      - https://web.archive.org/web/20200925075411id_/https://link.springer.com/article/10.1007/s00382-012-1331-2
       Memento-Datetime:
       - Fri, 25 Sep 2020 07:54:11 GMT
       Server:
@@ -282,7 +282,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post15.dev0+g11b25c8 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20200925075411id_/https://link.springer.com/article/10.1007/s00382-012-1331-2
+    uri: https://web.archive.org/web/20200925075411id_/https://link.springer.com/article/10.1007/s00382-012-1331-2
   response:
     body:
       string: ''
@@ -296,7 +296,7 @@ interactions:
       Date:
       - Thu, 01 Oct 2020 01:30:32 GMT
       Location:
-      - http://web.archive.org/web/20200925075402id_/https://link.springer.com/article/10.1007/s00382-012-1331-2
+      - https://web.archive.org/web/20200925075402id_/https://link.springer.com/article/10.1007/s00382-012-1331-2
       Server:
       - nginx/1.15.8
       Server-Timing:

--- a/wayback/tests/cassettes/test_get_memento_raises_no_memento_error
+++ b/wayback/tests/cassettes/test_get_memento_raises_no_memento_error
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.3.0a3.post0.dev0+g7e9bccc (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20170929002712id_/https://this-is-not-real-url.whatever/
+    uri: https://web.archive.org/web/20170929002712id_/https://this-is-not-real-url.whatever/
   response:
     body:
       string: !!binary |

--- a/wayback/tests/cassettes/test_get_memento_raises_when_memento_is_outside_target_window
+++ b/wayback/tests/cassettes/test_get_memento_raises_when_memento_is_outside_target_window
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post2.dev0+g0c2a63c (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20171101000000id_/https://www.fws.gov/birds/
+    uri: https://web.archive.org/web/20171101000000id_/https://www.fws.gov/birds/
   response:
     body:
       string: ''
@@ -21,7 +21,7 @@ interactions:
       Date:
       - Mon, 19 Oct 2020 08:07:14 GMT
       Location:
-      - http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+      - https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
       Server:
       - nginx/1.15.8
       Server-Timing:

--- a/wayback/tests/cassettes/test_get_memento_should_fail_for_non_playbackable_mementos
+++ b/wayback/tests/cassettes/test_get_memento_should_fail_for_non_playbackable_mementos
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - edgi.web_monitoring.WaybackClient/0.2.0a1.post0.dev0+g800608f
     method: GET
-    uri: http://web.archive.org/web/20170929002712id_/https://www.fws.gov/birds/
+    uri: https://web.archive.org/web/20170929002712id_/https://www.fws.gov/birds/
   response:
     body:
       string: ''
@@ -21,7 +21,7 @@ interactions:
       Date:
       - Mon, 18 Nov 2019 17:25:10 GMT
       Location:
-      - http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+      - https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
       Server:
       - nginx/1.15.8
       X-App-Server:

--- a/wayback/tests/cassettes/test_get_memento_target_window
+++ b/wayback/tests/cassettes/test_get_memento_target_window
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post2.dev0+g0c2a63c (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20171101000000id_/https://www.fws.gov/birds/
+    uri: https://web.archive.org/web/20171101000000id_/https://www.fws.gov/birds/
   response:
     body:
       string: ''
@@ -21,7 +21,7 @@ interactions:
       Date:
       - Mon, 19 Oct 2020 08:07:13 GMT
       Location:
-      - http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+      - https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
       Server:
       - nginx/1.15.8
       Server-Timing:
@@ -53,7 +53,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post2.dev0+g0c2a63c (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+    uri: https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
   response:
     body:
       string: !!binary |
@@ -501,13 +501,13 @@ interactions:
       Date:
       - Mon, 19 Oct 2020 08:07:14 GMT
       Link:
-      - <https://www.fws.gov/birds/>; rel="original", <http://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.fws.gov/birds/>;
-        rel="timegate", <http://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
-        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <http://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
-        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
-        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <http://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
-        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <http://web.archive.org/web/20201011123440/http://www.fws.gov/birds>;
+      - <https://www.fws.gov/birds/>; rel="original", <https://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.fws.gov/birds/>;
+        rel="timegate", <https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
+        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <https://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
+        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
+        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <https://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
+        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <https://web.archive.org/web/20201011123440/http://www.fws.gov/birds>;
         rel="last memento"; datetime="Sun, 11 Oct 2020 12:34:40 GMT"
       Memento-Datetime:
       - Fri, 24 Nov 2017 15:13:15 GMT

--- a/wayback/tests/cassettes/test_get_memento_with_archive_url
+++ b/wayback/tests/cassettes/test_get_memento_with_archive_url
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post9.dev0+g0fed660 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+    uri: https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
   response:
     body:
       string: !!binary |
@@ -455,13 +455,13 @@ interactions:
       Date:
       - Tue, 29 Sep 2020 23:18:14 GMT
       Link:
-      - <https://www.fws.gov/birds/>; rel="original", <http://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.fws.gov/birds/>;
-        rel="timegate", <http://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
-        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <http://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
-        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
-        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <http://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
-        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <http://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
+      - <https://www.fws.gov/birds/>; rel="original", <https://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.fws.gov/birds/>;
+        rel="timegate", <https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
+        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <https://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
+        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
+        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <https://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
+        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <https://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
         rel="last memento"; datetime="Sun, 13 Sep 2020 10:22:19 GMT"
       Memento-Datetime:
       - Fri, 24 Nov 2017 15:13:15 GMT

--- a/wayback/tests/cassettes/test_get_memento_with_cdx_record
+++ b/wayback/tests/cassettes/test_get_memento_with_cdx_record
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post9.dev0+g0fed660 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+    uri: https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
   response:
     body:
       string: !!binary |
@@ -455,13 +455,13 @@ interactions:
       Date:
       - Tue, 29 Sep 2020 23:18:14 GMT
       Link:
-      - <https://www.fws.gov/birds/>; rel="original", <http://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.fws.gov/birds/>;
-        rel="timegate", <http://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
-        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <http://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
-        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
-        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <http://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
-        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <http://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
+      - <https://www.fws.gov/birds/>; rel="original", <https://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.fws.gov/birds/>;
+        rel="timegate", <https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
+        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <https://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
+        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
+        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <https://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
+        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <https://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
         rel="last memento"; datetime="Sun, 13 Sep 2020 10:22:19 GMT"
       Memento-Datetime:
       - Fri, 24 Nov 2017 15:13:15 GMT

--- a/wayback/tests/cassettes/test_get_memento_with_date_datetime
+++ b/wayback/tests/cassettes/test_get_memento_with_date_datetime
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post17.dev0+g64f9364 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20171124000000id_/https://www.fws.gov/birds/
+    uri: https://web.archive.org/web/20171124000000id_/https://www.fws.gov/birds/
   response:
     body:
       string: ''
@@ -21,7 +21,7 @@ interactions:
       Date:
       - Thu, 01 Oct 2020 01:55:50 GMT
       Location:
-      - http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+      - https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
       Server:
       - nginx/1.15.8
       Server-Timing:
@@ -53,7 +53,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post17.dev0+g64f9364 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+    uri: https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
   response:
     body:
       string: !!binary |
@@ -501,13 +501,13 @@ interactions:
       Date:
       - Thu, 01 Oct 2020 01:55:50 GMT
       Link:
-      - <https://www.fws.gov/birds/>; rel="original", <http://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.fws.gov/birds/>;
-        rel="timegate", <http://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
-        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <http://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
-        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
-        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <http://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
-        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <http://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
+      - <https://www.fws.gov/birds/>; rel="original", <https://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.fws.gov/birds/>;
+        rel="timegate", <https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
+        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <https://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
+        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
+        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <https://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
+        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <https://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
         rel="last memento"; datetime="Sun, 13 Sep 2020 10:22:19 GMT"
       Memento-Datetime:
       - Fri, 24 Nov 2017 15:13:15 GMT

--- a/wayback/tests/cassettes/test_get_memento_with_inexact_string_datetime
+++ b/wayback/tests/cassettes/test_get_memento_with_inexact_string_datetime
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post20.dev0+g807c41b (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20171124151310id_/https://www.fws.gov/birds/
+    uri: https://web.archive.org/web/20171124151310id_/https://www.fws.gov/birds/
   response:
     body:
       string: ''
@@ -21,7 +21,7 @@ interactions:
       Date:
       - Fri, 02 Oct 2020 07:46:58 GMT
       Location:
-      - http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+      - https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
       Server:
       - nginx/1.15.8
       Server-Timing:
@@ -53,7 +53,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post20.dev0+g807c41b (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+    uri: https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
   response:
     body:
       string: !!binary |
@@ -501,13 +501,13 @@ interactions:
       Date:
       - Fri, 02 Oct 2020 07:46:58 GMT
       Link:
-      - <https://www.fws.gov/birds/>; rel="original", <http://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.fws.gov/birds/>;
-        rel="timegate", <http://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
-        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <http://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
-        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
-        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <http://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
-        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <http://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
+      - <https://www.fws.gov/birds/>; rel="original", <https://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.fws.gov/birds/>;
+        rel="timegate", <https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
+        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <https://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
+        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
+        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <https://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
+        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <https://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
         rel="last memento"; datetime="Sun, 13 Sep 2020 10:22:19 GMT"
       Memento-Datetime:
       - Fri, 24 Nov 2017 15:13:15 GMT

--- a/wayback/tests/cassettes/test_get_memento_with_mode
+++ b/wayback/tests/cassettes/test_get_memento_with_mode
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post9.dev0+g0fed660 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/
+    uri: https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/
   response:
     body:
       string: !!binary |
@@ -557,13 +557,13 @@ interactions:
       Date:
       - Tue, 29 Sep 2020 23:19:23 GMT
       Link:
-      - <https://www.fws.gov/birds/>; rel="original", <http://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.fws.gov/birds/>;
-        rel="timegate", <http://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
-        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <http://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
-        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
-        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <http://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
-        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <http://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
+      - <https://www.fws.gov/birds/>; rel="original", <https://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.fws.gov/birds/>;
+        rel="timegate", <https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
+        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <https://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
+        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
+        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <https://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
+        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <https://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
         rel="last memento"; datetime="Sun, 13 Sep 2020 10:22:19 GMT"
       Memento-Datetime:
       - Fri, 24 Nov 2017 15:13:15 GMT
@@ -611,7 +611,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post9.dev0+g0fed660 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+    uri: https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
   response:
     body:
       string: !!binary |
@@ -1059,13 +1059,13 @@ interactions:
       Date:
       - Tue, 29 Sep 2020 23:19:23 GMT
       Link:
-      - <https://www.fws.gov/birds/>; rel="original", <http://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.fws.gov/birds/>;
-        rel="timegate", <http://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
-        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <http://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
-        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
-        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <http://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
-        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <http://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
+      - <https://www.fws.gov/birds/>; rel="original", <https://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.fws.gov/birds/>;
+        rel="timegate", <https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
+        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <https://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
+        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
+        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <https://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
+        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <https://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
         rel="last memento"; datetime="Sun, 13 Sep 2020 10:22:19 GMT"
       Memento-Datetime:
       - Fri, 24 Nov 2017 15:13:15 GMT

--- a/wayback/tests/cassettes/test_get_memento_with_mode_string
+++ b/wayback/tests/cassettes/test_get_memento_with_mode_string
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post10.dev0+gf2d2bbb (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+    uri: https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
   response:
     body:
       string: !!binary |
@@ -455,13 +455,13 @@ interactions:
       Date:
       - Wed, 30 Sep 2020 01:22:47 GMT
       Link:
-      - <https://www.fws.gov/birds/>; rel="original", <http://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.fws.gov/birds/>;
-        rel="timegate", <http://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
-        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <http://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
-        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
-        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <http://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
-        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <http://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
+      - <https://www.fws.gov/birds/>; rel="original", <https://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.fws.gov/birds/>;
+        rel="timegate", <https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
+        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <https://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
+        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
+        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <https://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
+        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <https://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
         rel="last memento"; datetime="Sun, 13 Sep 2020 10:22:19 GMT"
       Memento-Datetime:
       - Fri, 24 Nov 2017 15:13:15 GMT

--- a/wayback/tests/cassettes/test_get_memento_with_path_based_redirects
+++ b/wayback/tests/cassettes/test_get_memento_with_path_based_redirects
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.3.0a1.post0.dev0+gee40997 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20201027215555id_/https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs
+    uri: https://web.archive.org/web/20201027215555id_/https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs
   response:
     body:
       string: ''
@@ -25,13 +25,13 @@ interactions:
       - Tue, 03 Nov 2020 03:08:42 GMT
       Link:
       - <https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs>; rel="original",
-        <http://web.archive.org/web/timemap/link/https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs>;
-        rel="timegate", <http://web.archive.org/web/20140808023002/http://www.whitehouse.gov/administration/eop/ostp/about/student/faqs>;
-        rel="first memento"; datetime="Fri, 08 Aug 2014 02:30:02 GMT", <http://web.archive.org/web/20201026212550/https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs>;
-        rel="prev memento"; datetime="Mon, 26 Oct 2020 21:25:50 GMT", <http://web.archive.org/web/20201027215555/https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs>;
-        rel="memento"; datetime="Tue, 27 Oct 2020 21:55:55 GMT", <http://web.archive.org/web/20201028224313/https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs>;
-        rel="next memento"; datetime="Wed, 28 Oct 2020 22:43:13 GMT", <http://web.archive.org/web/20201102004524/https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs>;
+        <https://web.archive.org/web/timemap/link/https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs>;
+        rel="timegate", <https://web.archive.org/web/20140808023002/http://www.whitehouse.gov/administration/eop/ostp/about/student/faqs>;
+        rel="first memento"; datetime="Fri, 08 Aug 2014 02:30:02 GMT", <https://web.archive.org/web/20201026212550/https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs>;
+        rel="prev memento"; datetime="Mon, 26 Oct 2020 21:25:50 GMT", <https://web.archive.org/web/20201027215555/https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs>;
+        rel="memento"; datetime="Tue, 27 Oct 2020 21:55:55 GMT", <https://web.archive.org/web/20201028224313/https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs>;
+        rel="next memento"; datetime="Wed, 28 Oct 2020 22:43:13 GMT", <https://web.archive.org/web/20201102004524/https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs>;
         rel="last memento"; datetime="Mon, 02 Nov 2020 00:45:24 GMT"
       Location:
       - /web/20201027215555id_/https://www.whitehouse.gov/ostp/about/student/faqs
@@ -91,7 +91,7 @@ interactions:
       User-Agent:
       - wayback/0.3.0a1.post0.dev0+gee40997 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20201027215555id_/https://www.whitehouse.gov/ostp/about/student/faqs
+    uri: https://web.archive.org/web/20201027215555id_/https://www.whitehouse.gov/ostp/about/student/faqs
   response:
     body:
       string: ''
@@ -105,7 +105,7 @@ interactions:
       Date:
       - Tue, 03 Nov 2020 03:08:42 GMT
       Location:
-      - http://web.archive.org/web/20201027220743id_/https://www.whitehouse.gov/ostp/about/student/faqs
+      - https://web.archive.org/web/20201027220743id_/https://www.whitehouse.gov/ostp/about/student/faqs
       Server:
       - nginx/1.15.8
       Server-Timing:
@@ -137,7 +137,7 @@ interactions:
       User-Agent:
       - wayback/0.3.0a1.post0.dev0+gee40997 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20201027220743id_/https://www.whitehouse.gov/ostp/about/student/faqs
+    uri: https://web.archive.org/web/20201027220743id_/https://www.whitehouse.gov/ostp/about/student/faqs
   response:
     body:
       string: !!binary |
@@ -420,13 +420,13 @@ interactions:
       Date:
       - Tue, 03 Nov 2020 03:08:42 GMT
       Link:
-      - <https://www.whitehouse.gov/ostp/about/student/faqs>; rel="original", <http://web.archive.org/web/timemap/link/https://www.whitehouse.gov/ostp/about/student/faqs>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.whitehouse.gov/ostp/about/student/faqs>;
-        rel="timegate", <http://web.archive.org/web/20171222125647/https://www.whitehouse.gov/ostp/about/student/faqs>;
-        rel="first memento"; datetime="Fri, 22 Dec 2017 12:56:47 GMT", <http://web.archive.org/web/20201026213635/https://www.whitehouse.gov/ostp/about/student/faqs>;
-        rel="prev memento"; datetime="Mon, 26 Oct 2020 21:36:35 GMT", <http://web.archive.org/web/20201027220743/https://www.whitehouse.gov/ostp/about/student/faqs>;
-        rel="memento"; datetime="Tue, 27 Oct 2020 22:07:43 GMT", <http://web.archive.org/web/20201028225518/https://www.whitehouse.gov/ostp/about/student/faqs>;
-        rel="next memento"; datetime="Wed, 28 Oct 2020 22:55:18 GMT", <http://web.archive.org/web/20201031000029/https://www.whitehouse.gov/ostp/about/student/faqs>;
+      - <https://www.whitehouse.gov/ostp/about/student/faqs>; rel="original", <https://web.archive.org/web/timemap/link/https://www.whitehouse.gov/ostp/about/student/faqs>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.whitehouse.gov/ostp/about/student/faqs>;
+        rel="timegate", <https://web.archive.org/web/20171222125647/https://www.whitehouse.gov/ostp/about/student/faqs>;
+        rel="first memento"; datetime="Fri, 22 Dec 2017 12:56:47 GMT", <https://web.archive.org/web/20201026213635/https://www.whitehouse.gov/ostp/about/student/faqs>;
+        rel="prev memento"; datetime="Mon, 26 Oct 2020 21:36:35 GMT", <https://web.archive.org/web/20201027220743/https://www.whitehouse.gov/ostp/about/student/faqs>;
+        rel="memento"; datetime="Tue, 27 Oct 2020 22:07:43 GMT", <https://web.archive.org/web/20201028225518/https://www.whitehouse.gov/ostp/about/student/faqs>;
+        rel="next memento"; datetime="Wed, 28 Oct 2020 22:55:18 GMT", <https://web.archive.org/web/20201031000029/https://www.whitehouse.gov/ostp/about/student/faqs>;
         rel="last memento"; datetime="Sat, 31 Oct 2020 00:00:29 GMT"
       Memento-Datetime:
       - Tue, 27 Oct 2020 22:07:43 GMT

--- a/wayback/tests/cassettes/test_get_memento_with_redirects
+++ b/wayback/tests/cassettes/test_get_memento_with_redirects
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post9.dev0+g0fed660 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20180808094144id_/https://www.epa.gov/ghgreporting/san5779-factsheet
+    uri: https://web.archive.org/web/20180808094144id_/https://www.epa.gov/ghgreporting/san5779-factsheet
   response:
     body:
       string: ''
@@ -24,16 +24,16 @@ interactions:
       Date:
       - Tue, 29 Sep 2020 23:18:15 GMT
       Link:
-      - <https://www.epa.gov/ghgreporting/san5779-factsheet>; rel="original", <http://web.archive.org/web/timemap/link/https://www.epa.gov/ghgreporting/san5779-factsheet>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.epa.gov/ghgreporting/san5779-factsheet>;
-        rel="timegate", <http://web.archive.org/web/20150921195814/http://www2.epa.gov/ghgreporting/san5779-factsheet>;
-        rel="first memento"; datetime="Mon, 21 Sep 2015 19:58:14 GMT", <http://web.archive.org/web/20180807093520/https://www.epa.gov/ghgreporting/san5779-factsheet>;
-        rel="prev memento"; datetime="Tue, 07 Aug 2018 09:35:20 GMT", <http://web.archive.org/web/20180808094144/https://www.epa.gov/ghgreporting/san5779-factsheet>;
-        rel="memento"; datetime="Wed, 08 Aug 2018 09:41:44 GMT", <http://web.archive.org/web/20180809102441/https://www.epa.gov/ghgreporting/san5779-factsheet>;
-        rel="next memento"; datetime="Thu, 09 Aug 2018 10:24:41 GMT", <http://web.archive.org/web/20200927103712/https://www.epa.gov/ghgreporting/san5779-factsheet>;
+      - <https://www.epa.gov/ghgreporting/san5779-factsheet>; rel="original", <https://web.archive.org/web/timemap/link/https://www.epa.gov/ghgreporting/san5779-factsheet>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.epa.gov/ghgreporting/san5779-factsheet>;
+        rel="timegate", <https://web.archive.org/web/20150921195814/http://www2.epa.gov/ghgreporting/san5779-factsheet>;
+        rel="first memento"; datetime="Mon, 21 Sep 2015 19:58:14 GMT", <https://web.archive.org/web/20180807093520/https://www.epa.gov/ghgreporting/san5779-factsheet>;
+        rel="prev memento"; datetime="Tue, 07 Aug 2018 09:35:20 GMT", <https://web.archive.org/web/20180808094144/https://www.epa.gov/ghgreporting/san5779-factsheet>;
+        rel="memento"; datetime="Wed, 08 Aug 2018 09:41:44 GMT", <https://web.archive.org/web/20180809102441/https://www.epa.gov/ghgreporting/san5779-factsheet>;
+        rel="next memento"; datetime="Thu, 09 Aug 2018 10:24:41 GMT", <https://web.archive.org/web/20200927103712/https://www.epa.gov/ghgreporting/san5779-factsheet>;
         rel="last memento"; datetime="Sun, 27 Sep 2020 10:37:12 GMT"
       Location:
-      - http://web.archive.org/web/20180808094144id_/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming
+      - https://web.archive.org/web/20180808094144id_/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming
       Memento-Datetime:
       - Wed, 08 Aug 2018 09:41:44 GMT
       Server:
@@ -90,7 +90,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post9.dev0+g0fed660 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20180808094144id_/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming
+    uri: https://web.archive.org/web/20180808094144id_/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming
   response:
     body:
       string: ''
@@ -104,7 +104,7 @@ interactions:
       Date:
       - Tue, 29 Sep 2020 23:18:17 GMT
       Location:
-      - http://web.archive.org/web/20180808104500id_/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming
+      - https://web.archive.org/web/20180808104500id_/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming
       Server:
       - nginx/1.15.8
       Server-Timing:
@@ -137,7 +137,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post9.dev0+g0fed660 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20180808104500id_/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming
+    uri: https://web.archive.org/web/20180808104500id_/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming
   response:
     body:
       string: !!binary |
@@ -391,13 +391,13 @@ interactions:
       - Tue, 29 Sep 2020 23:18:18 GMT
       Link:
       - <https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming>;
-        rel="original", <http://web.archive.org/web/timemap/link/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming>;
-        rel="timegate", <http://web.archive.org/web/20150922221816/http://www2.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming>;
-        rel="first memento"; datetime="Tue, 22 Sep 2015 22:18:16 GMT", <http://web.archive.org/web/20180807105844/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming>;
-        rel="prev memento"; datetime="Tue, 07 Aug 2018 10:58:44 GMT", <http://web.archive.org/web/20180808104500/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming>;
-        rel="memento"; datetime="Wed, 08 Aug 2018 10:45:00 GMT", <http://web.archive.org/web/20180809112339/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming>;
-        rel="next memento"; datetime="Thu, 09 Aug 2018 11:23:39 GMT", <http://web.archive.org/web/20200926182800/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming>;
+        rel="original", <https://web.archive.org/web/timemap/link/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming>;
+        rel="timegate", <https://web.archive.org/web/20150922221816/http://www2.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming>;
+        rel="first memento"; datetime="Tue, 22 Sep 2015 22:18:16 GMT", <https://web.archive.org/web/20180807105844/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming>;
+        rel="prev memento"; datetime="Tue, 07 Aug 2018 10:58:44 GMT", <https://web.archive.org/web/20180808104500/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming>;
+        rel="memento"; datetime="Wed, 08 Aug 2018 10:45:00 GMT", <https://web.archive.org/web/20180809112339/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming>;
+        rel="next memento"; datetime="Thu, 09 Aug 2018 11:23:39 GMT", <https://web.archive.org/web/20200926182800/https://www.epa.gov/ghgreporting/proposed-rule-fact-sheet-greenhouse-gas-reporting-program-addition-global-warming>;
         rel="last memento"; datetime="Sat, 26 Sep 2020 18:28:00 GMT"
       Memento-Datetime:
       - Wed, 08 Aug 2018 10:45:00 GMT

--- a/wayback/tests/cassettes/test_get_memento_with_schemeless_redirects
+++ b/wayback/tests/cassettes/test_get_memento_with_schemeless_redirects
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.3.0a2.post0.dev0+gc2ca979 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20201102232816id_/https://www.census.gov/geography/gss-initiative.html
+    uri: https://web.archive.org/web/20201102232816id_/https://www.census.gov/geography/gss-initiative.html
   response:
     body:
       string: "\n\n                    \n\n                    \n                    \n
@@ -1727,13 +1727,13 @@ interactions:
       Date:
       - Fri, 06 Nov 2020 01:22:16 GMT
       Link:
-      - <https://www.census.gov/geography/gss-initiative.html>; rel="original", <http://web.archive.org/web/timemap/link/https://www.census.gov/geography/gss-initiative.html>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.census.gov/geography/gss-initiative.html>;
-        rel="timegate", <http://web.archive.org/web/20150924052631/http://www.census.gov:80/geography/gss-initiative.html>;
-        rel="first memento"; datetime="Thu, 24 Sep 2015 05:26:31 GMT", <http://web.archive.org/web/20201101215426/https://www.census.gov/geography/gss-initiative.html>;
-        rel="prev memento"; datetime="Sun, 01 Nov 2020 21:54:26 GMT", <http://web.archive.org/web/20201102232816/https://www.census.gov/geography/gss-initiative.html>;
-        rel="memento"; datetime="Mon, 02 Nov 2020 23:28:16 GMT", <http://web.archive.org/web/20201104000002/https://www.census.gov/geography/gss-initiative.html>;
-        rel="next memento"; datetime="Wed, 04 Nov 2020 00:00:02 GMT", <http://web.archive.org/web/20201105002042/https://www.census.gov/geography/gss-initiative.html>;
+      - <https://www.census.gov/geography/gss-initiative.html>; rel="original", <https://web.archive.org/web/timemap/link/https://www.census.gov/geography/gss-initiative.html>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.census.gov/geography/gss-initiative.html>;
+        rel="timegate", <https://web.archive.org/web/20150924052631/http://www.census.gov:80/geography/gss-initiative.html>;
+        rel="first memento"; datetime="Thu, 24 Sep 2015 05:26:31 GMT", <https://web.archive.org/web/20201101215426/https://www.census.gov/geography/gss-initiative.html>;
+        rel="prev memento"; datetime="Sun, 01 Nov 2020 21:54:26 GMT", <https://web.archive.org/web/20201102232816/https://www.census.gov/geography/gss-initiative.html>;
+        rel="memento"; datetime="Mon, 02 Nov 2020 23:28:16 GMT", <https://web.archive.org/web/20201104000002/https://www.census.gov/geography/gss-initiative.html>;
+        rel="next memento"; datetime="Wed, 04 Nov 2020 00:00:02 GMT", <https://web.archive.org/web/20201105002042/https://www.census.gov/geography/gss-initiative.html>;
         rel="last memento"; datetime="Thu, 05 Nov 2020 00:20:42 GMT"
       Location:
       - //web.archive.org/web/20201102232816id_/https://www.census.gov/geo/gssi/
@@ -1798,7 +1798,7 @@ interactions:
       User-Agent:
       - wayback/0.3.0a2.post0.dev0+gc2ca979 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20201102232816id_/https://www.census.gov/geo/gssi/
+    uri: https://web.archive.org/web/20201102232816id_/https://www.census.gov/geo/gssi/
   response:
     body:
       string: ''
@@ -1812,7 +1812,7 @@ interactions:
       Date:
       - Fri, 06 Nov 2020 01:22:16 GMT
       Location:
-      - http://web.archive.org/web/20201102233026id_/https://www.census.gov/geo/gssi/
+      - https://web.archive.org/web/20201102233026id_/https://www.census.gov/geo/gssi/
       Server:
       - nginx/1.15.8
       Server-Timing:
@@ -1844,7 +1844,7 @@ interactions:
       User-Agent:
       - wayback/0.3.0a2.post0.dev0+gc2ca979 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20201102233026id_/https://www.census.gov/geo/gssi/
+    uri: https://web.archive.org/web/20201102233026id_/https://www.census.gov/geo/gssi/
   response:
     body:
       string: !!binary |
@@ -1966,13 +1966,13 @@ interactions:
       Date:
       - Fri, 06 Nov 2020 01:22:16 GMT
       Link:
-      - <https://www.census.gov/geo/gssi/>; rel="original", <http://web.archive.org/web/timemap/link/https://www.census.gov/geo/gssi/>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.census.gov/geo/gssi/>;
-        rel="timegate", <http://web.archive.org/web/20140903165709/https://www.census.gov/geo/gssi/>;
-        rel="first memento"; datetime="Wed, 03 Sep 2014 16:57:09 GMT", <http://web.archive.org/web/20201101215632/https://www.census.gov/geo/gssi/>;
-        rel="prev memento"; datetime="Sun, 01 Nov 2020 21:56:32 GMT", <http://web.archive.org/web/20201102233026/https://www.census.gov/geo/gssi/>;
-        rel="memento"; datetime="Mon, 02 Nov 2020 23:30:26 GMT", <http://web.archive.org/web/20201104000219/https://www.census.gov/geo/gssi/>;
-        rel="next memento"; datetime="Wed, 04 Nov 2020 00:02:19 GMT", <http://web.archive.org/web/20201105002246/https://www.census.gov/geo/gssi/>;
+      - <https://www.census.gov/geo/gssi/>; rel="original", <https://web.archive.org/web/timemap/link/https://www.census.gov/geo/gssi/>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.census.gov/geo/gssi/>;
+        rel="timegate", <https://web.archive.org/web/20140903165709/https://www.census.gov/geo/gssi/>;
+        rel="first memento"; datetime="Wed, 03 Sep 2014 16:57:09 GMT", <https://web.archive.org/web/20201101215632/https://www.census.gov/geo/gssi/>;
+        rel="prev memento"; datetime="Sun, 01 Nov 2020 21:56:32 GMT", <https://web.archive.org/web/20201102233026/https://www.census.gov/geo/gssi/>;
+        rel="memento"; datetime="Mon, 02 Nov 2020 23:30:26 GMT", <https://web.archive.org/web/20201104000219/https://www.census.gov/geo/gssi/>;
+        rel="next memento"; datetime="Wed, 04 Nov 2020 00:02:19 GMT", <https://web.archive.org/web/20201105002246/https://www.census.gov/geo/gssi/>;
         rel="last memento"; datetime="Thu, 05 Nov 2020 00:22:46 GMT"
       Memento-Datetime:
       - Mon, 02 Nov 2020 23:30:26 GMT

--- a/wayback/tests/cassettes/test_get_memento_with_string_datetime
+++ b/wayback/tests/cassettes/test_get_memento_with_string_datetime
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.2.4.post17.dev0+g64f9364 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
+    uri: https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/
   response:
     body:
       string: !!binary |
@@ -455,13 +455,13 @@ interactions:
       Date:
       - Thu, 01 Oct 2020 01:55:51 GMT
       Link:
-      - <https://www.fws.gov/birds/>; rel="original", <http://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
-        rel="timemap"; type="application/link-format", <http://web.archive.org/web/https://www.fws.gov/birds/>;
-        rel="timegate", <http://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
-        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <http://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
-        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
-        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <http://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
-        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <http://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
+      - <https://www.fws.gov/birds/>; rel="original", <https://web.archive.org/web/timemap/link/https://www.fws.gov/birds/>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.fws.gov/birds/>;
+        rel="timegate", <https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds>;
+        rel="first memento"; datetime="Wed, 23 Mar 2005 15:53:00 GMT", <https://web.archive.org/web/20170929002712/https://www.fws.gov/birds/>;
+        rel="prev memento"; datetime="Fri, 29 Sep 2017 00:27:12 GMT", <https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/>;
+        rel="memento"; datetime="Fri, 24 Nov 2017 15:13:15 GMT", <https://web.archive.org/web/20171228222143/https://www.fws.gov/birds/>;
+        rel="next memento"; datetime="Thu, 28 Dec 2017 22:21:43 GMT", <https://web.archive.org/web/20200913102219/https://www.fws.gov/birds/>;
         rel="last memento"; datetime="Sun, 13 Sep 2020 10:22:19 GMT"
       Memento-Datetime:
       - Fri, 24 Nov 2017 15:13:15 GMT

--- a/wayback/tests/cassettes/test_search
+++ b/wayback/tests/cassettes/test_search
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=nasa.gov&limit=1000&from=19961001000000&to=19970201000000&showResumeKey=true&resolveRevisits=true
+    uri: https://web.archive.org/cdx/search/cdx?url=nasa.gov&limit=1000&from=19961001000000&to=19970201000000&showResumeKey=true&resolveRevisits=true
   response:
     body:
       string: !!binary |

--- a/wayback/tests/cassettes/test_search_does_not_repeat_results
+++ b/wayback/tests/cassettes/test_search_does_not_repeat_results
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=energystar.gov%2F&limit=1000&from=20200612000000&to=20200613000000&showResumeKey=true&resolveRevisits=true
+    uri: https://web.archive.org/cdx/search/cdx?url=energystar.gov%2F&limit=1000&from=20200612000000&to=20200613000000&showResumeKey=true&resolveRevisits=true
   response:
     body:
       string: !!binary |

--- a/wayback/tests/cassettes/test_search_multipage
+++ b/wayback/tests/cassettes/test_search_multipage
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true
+    uri: https://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true
   response:
     body:
       string: !!binary |
@@ -62,7 +62,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B2001041400593%253A
+    uri: https://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B2001041400593%253A
   response:
     body:
       string: !!binary |
@@ -117,7 +117,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010503212619
+    uri: https://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010503212619
   response:
     body:
       string: !!binary |
@@ -171,7 +171,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010504092326
+    uri: https://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010504092326
   response:
     body:
       string: !!binary |
@@ -226,7 +226,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010505085533
+    uri: https://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010505085533
   response:
     body:
       string: !!binary |
@@ -280,7 +280,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010505091254
+    uri: https://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010505091254
   response:
     body:
       string: !!binary |
@@ -335,7 +335,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010506001449
+    uri: https://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010506001449
   response:
     body:
       string: !!binary |
@@ -390,7 +390,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010506010648
+    uri: https://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010506010648
   response:
     body:
       string: !!binary |
@@ -443,7 +443,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B2001050614125%253A
+    uri: https://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B2001050614125%253A
   response:
     body:
       string: !!binary |
@@ -497,7 +497,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010507021559
+    uri: https://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010507021559
   response:
     body:
       string: !!binary |
@@ -552,7 +552,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010507180423
+    uri: https://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010507180423
   response:
     body:
       string: !!binary |
@@ -607,7 +607,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B2001050807025%253A
+    uri: https://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B2001050807025%253A
   response:
     body:
       string: !!binary |
@@ -661,7 +661,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010508143112
+    uri: https://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010508143112
   response:
     body:
       string: !!binary |
@@ -716,7 +716,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B2001050910252%253A
+    uri: https://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B2001050910252%253A
   response:
     body:
       string: !!binary |
@@ -771,7 +771,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010509235545
+    uri: https://web.archive.org/cdx/search/cdx?url=cnn.com&limit=25&from=20010410000000&to=20010510000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Ccnn%2529%252F%2B20010509235545
   response:
     body:
       string: !!binary |

--- a/wayback/tests/cassettes/test_search_raises_for_blocked_urls
+++ b/wayback/tests/cassettes/test_search_raises_for_blocked_urls
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.2.3.post12.dev0+g6d3e887 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=https%3A%2F%2Fnationalpost.com%2Fhealth&limit=1000&from=20191001000000&to=20191002000000&showResumeKey=true&resolveRevisits=true
+    uri: https://web.archive.org/cdx/search/cdx?url=https%3A%2F%2Fnationalpost.com%2Fhealth&limit=1000&from=20191001000000&to=20191002000000&showResumeKey=true&resolveRevisits=true
   response:
     body:
       string: !!binary |

--- a/wayback/tests/cassettes/test_search_with_date
+++ b/wayback/tests/cassettes/test_search_with_date
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=dw.com&limit=1000&from=20191001000000&to=20200301000000&showResumeKey=true&resolveRevisits=true
+    uri: https://web.archive.org/cdx/search/cdx?url=dw.com&limit=1000&from=20191001000000&to=20200301000000&showResumeKey=true&resolveRevisits=true
   response:
     body:
       string: !!binary |
@@ -189,7 +189,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=dw.com&limit=1000&from=20191001000000&to=20200301000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Cdw%2529%252F%2B20191218145126
+    uri: https://web.archive.org/cdx/search/cdx?url=dw.com&limit=1000&from=20191001000000&to=20200301000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Cdw%2529%252F%2B20191218145126
   response:
     body:
       string: !!binary |
@@ -366,7 +366,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=dw.com&limit=1000&from=20191001000000&to=20200301000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Cdw%2529%252F%2B20200220202228
+    uri: https://web.archive.org/cdx/search/cdx?url=dw.com&limit=1000&from=20191001000000&to=20200301000000&showResumeKey=true&resolveRevisits=true&resumeKey=com%252Cdw%2529%252F%2B20200220202228
   response:
     body:
       string: !!binary |

--- a/wayback/tests/cassettes/test_search_with_timezone
+++ b/wayback/tests/cassettes/test_search_with_timezone
@@ -7,7 +7,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=nasa.gov&limit=1000&from=19961231235847&showResumeKey=true&resolveRevisits=true
+    uri: https://web.archive.org/cdx/search/cdx?url=nasa.gov&limit=1000&from=19961231235847&showResumeKey=true&resolveRevisits=true
   response:
     body:
       string: !!binary |
@@ -243,7 +243,7 @@ interactions:
       User-Agent:
       - wayback/0.3.3.post6.dev0+ga3e1512 (+https://github.com/edgi-govdata-archiving/wayback)
     method: GET
-    uri: http://web.archive.org/cdx/search/cdx?url=nasa.gov&limit=1000&from=19970101045847&showResumeKey=true&resolveRevisits=true
+    uri: https://web.archive.org/cdx/search/cdx?url=nasa.gov&limit=1000&from=19970101045847&showResumeKey=true&resolveRevisits=true
   response:
     body:
       string: !!binary |

--- a/wayback/tests/test_client.py
+++ b/wayback/tests/test_client.py
@@ -165,7 +165,7 @@ def test_search_removes_malformed_entries(requests_mock):
         bad_cdx_data = f.read()
 
     with WaybackClient() as client:
-        requests_mock.get('http://web.archive.org/cdx/search/cdx'
+        requests_mock.get('https://web.archive.org/cdx/search/cdx'
                           '?url=https%3A%2F%2Fepa.gov%2F%2A'
                           '&from=20200418000000&to=20200419000000'
                           '&showResumeKey=true&resolveRevisits=true',
@@ -189,7 +189,7 @@ def test_search_handles_no_length_cdx_records(requests_mock):
         bad_cdx_data = f.read()
 
     with WaybackClient() as client:
-        requests_mock.get('http://web.archive.org/cdx/search/cdx'
+        requests_mock.get('https://web.archive.org/cdx/search/cdx'
                           '?url=www.cnn.com%2F%2A'
                           '&matchType=domain&filter=statuscode%3A200'
                           '&showResumeKey=true&resolveRevisits=true',
@@ -217,7 +217,7 @@ def test_search_handles_bad_timestamp_cdx_records(requests_mock):
         bad_cdx_data = f.read()
 
     with WaybackClient() as client:
-        requests_mock.get('http://web.archive.org/cdx/search/cdx'
+        requests_mock.get('https://web.archive.org/cdx/search/cdx'
                           '?url=www.usatoday.com%2F%2A'
                           '&matchType=domain&filter=statuscode%3A200'
                           '&showResumeKey=true&resolveRevisits=true',
@@ -311,13 +311,13 @@ def test_get_memento_with_requires_datetime_with_regular_url():
 def test_get_memento_with_archive_url():
     with WaybackClient() as client:
         memento = client.get_memento(
-            'http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/')
+            'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/')
 
         # Metadata About the Memento
         assert 'https://www.fws.gov/birds/' == memento.url
         assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
         assert 'id_' == memento.mode
-        assert 'http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/' == memento.memento_url
+        assert 'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/' == memento.memento_url
         assert () == memento.history
         assert () == memento.debug_history
 
@@ -346,8 +346,8 @@ def test_get_memento_with_cdx_record():
                            200,
                            'abc',
                            100,
-                           'http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/',
-                           'http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/')
+                           'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/',
+                           'https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/')
         memento = client.get_memento(record)
         assert 'https://www.fws.gov/birds/' == memento.url
         assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
@@ -361,12 +361,12 @@ def test_get_memento_with_mode():
                                      datetime=datetime(2017, 11, 24, 15, 13, 15),
                                      mode=Mode.view)
         assert '' == memento.mode
-        assert 'http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/' == memento.memento_url
+        assert 'https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/' == memento.memento_url
 
         memento = client.get_memento('https://www.fws.gov/birds/',
                                      datetime=datetime(2017, 11, 24, 15, 13, 15))
         assert 'id_' == memento.mode
-        assert 'http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/' == memento.memento_url
+        assert 'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/' == memento.memento_url
 
 
 @ia_vcr.use_cassette()
@@ -376,7 +376,7 @@ def test_get_memento_with_mode_string():
                                      datetime=datetime(2017, 11, 24, 15, 13, 15),
                                      mode='id_')
         assert 'id_' == memento.mode
-        assert 'http://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/' == memento.memento_url
+        assert 'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/' == memento.memento_url
 
 
 @ia_vcr.use_cassette()
@@ -412,7 +412,7 @@ def test_get_memento_raises_when_memento_is_outside_target_window():
 def test_get_memento_with_redirects():
     with WaybackClient() as client:
         memento = client.get_memento(
-            'http://web.archive.org/web/20180808094144id_/https://www.epa.gov/ghgreporting/san5779-factsheet')
+            'https://web.archive.org/web/20180808094144id_/https://www.epa.gov/ghgreporting/san5779-factsheet')
         assert len(memento.history) == 1        # memento redirects
         assert len(memento.debug_history) == 2  # actual HTTP redirects
 
@@ -421,7 +421,7 @@ def test_get_memento_with_redirects():
 def test_get_memento_with_path_based_redirects():
     """
     Most redirects in Wayback redirect to a complete URL, with headers like:
-        Location: http://web.archive.org/web/20201027215555id_/https://www.whitehouse.gov/administration
+        Location: https://web.archive.org/web/20201027215555id_/https://www.whitehouse.gov/administration
     But some include only an absolute path, e.g:
         Location: /web/20201027215555id_/https://www.whitehouse.gov/ostp/about/student/faqs
     This tests that we correctly handle the latter situation.
@@ -437,7 +437,7 @@ def test_get_memento_with_path_based_redirects():
 def test_get_memento_with_schemeless_redirects():
     """
     Most redirects in Wayback redirect to a complete URL, with headers like:
-        Location: http://web.archive.org/web/20201027215555id_/https://www.whitehouse.gov/administration
+        Location: https://web.archive.org/web/20201027215555id_/https://www.whitehouse.gov/administration
     But some do not include a scheme:
         Location: //web.archive.org/web/20201102232816id_/https://www.census.gov/geo/gssi/
     This tests that we correctly handle the latter situation.
@@ -487,16 +487,16 @@ def test_get_memento_follows_historical_redirects():
         #   https://www.epa.gov/sites/production/files/signpost/cc.html
         #
         # What should happen here under the hood:
-        # http://web.archive.org/web/20200201020357id_/http://epa.gov/climatechange
+        # https://web.archive.org/web/20200201020357id_/http://epa.gov/climatechange
         #   Is not a memento, and sends us to:
-        #   http://web.archive.org/web/20200201023757id_/https://www.epa.gov/climatechange
+        #   https://web.archive.org/web/20200201023757id_/https://www.epa.gov/climatechange
         #     Which is a memento of a redirect to:
-        #     http://web.archive.org/web/20200201023757id_/https://www.epa.gov/sites/production/files/signpost/cc.html
+        #     https://web.archive.org/web/20200201023757id_/https://www.epa.gov/sites/production/files/signpost/cc.html
         #       ...which is not a memento, and redirects to:
-        #       http://web.archive.org/web/20200201024405id_/https://www.epa.gov/sites/production/files/signpost/cc.html
-        start_url = ('http://web.archive.org/web/20200201020357id_/'
+        #       https://web.archive.org/web/20200201024405id_/https://www.epa.gov/sites/production/files/signpost/cc.html
+        start_url = ('https://web.archive.org/web/20200201020357id_/'
                      'http://epa.gov/climatechange')
-        target = ('http://web.archive.org/web/20200201024405id_/'
+        target = ('https://web.archive.org/web/20200201024405id_/'
                   'https://www.epa.gov/sites/production/files/signpost/cc.html')
         memento = client.get_memento(start_url, exact=False)
         assert 'https://www.epa.gov/sites/production/files/signpost/cc.html' == memento.url
@@ -512,17 +512,17 @@ def test_get_memento_follow_redirects_does_not_follow_historical_redirects():
         #   https://www.epa.gov/sites/production/files/signpost/cc.html
         #
         # What should happen here under the hood:
-        # http://web.archive.org/web/20200201020357id_/http://epa.gov/climatechange
+        # https://web.archive.org/web/20200201020357id_/http://epa.gov/climatechange
         #   Is not a memento, and sends us to:
-        #   http://web.archive.org/web/20200201023757id_/https://www.epa.gov/climatechange
+        #   https://web.archive.org/web/20200201023757id_/https://www.epa.gov/climatechange
         #     Which is a memento of a redirect. Because follow_redirects=False,
         #     we should *not* follow it to:
-        #     http://web.archive.org/web/20200201023757id_/https://www.epa.gov/sites/production/files/signpost/cc.html
+        #     https://web.archive.org/web/20200201023757id_/https://www.epa.gov/sites/production/files/signpost/cc.html
         #       ...and then to:
-        #       http://web.archive.org/web/20200201024405id_/https://www.epa.gov/sites/production/files/signpost/cc.html
-        start_url = ('http://web.archive.org/web/20200201020357id_/'
+        #       https://web.archive.org/web/20200201024405id_/https://www.epa.gov/sites/production/files/signpost/cc.html
+        start_url = ('https://web.archive.org/web/20200201020357id_/'
                      'http://epa.gov/climatechange')
-        target = ('http://web.archive.org/web/20200201023757id_/'
+        target = ('https://web.archive.org/web/20200201023757id_/'
                   'https://www.epa.gov/climatechange')
         memento = client.get_memento(start_url, exact=False, follow_redirects=False)
         assert 'https://www.epa.gov/climatechange' == memento.url

--- a/wayback/tests/test_utils.py
+++ b/wayback/tests/test_utils.py
@@ -6,14 +6,14 @@ from .._utils import memento_url_data
 class TestMementoUrlData:
     def test_extracts_url(self):
         url, timestamp, mode = memento_url_data(
-            'http://web.archive.org/web/20170813195036/'
+            'https://web.archive.org/web/20170813195036/'
             'https://arpa-e.energy.gov/?q=engage/events-workshops')
         assert url == 'https://arpa-e.energy.gov/?q=engage/events-workshops'
         assert timestamp == datetime(2017, 8, 13, 19, 50, 36, tzinfo=timezone.utc)
         assert mode == ''
 
         url, timestamp, mode = memento_url_data(
-            'http://web.archive.org/web/20170813195036id_/'
+            'https://web.archive.org/web/20170813195036id_/'
             'https://arpa-e.energy.gov/?q=engage/events-workshops')
         assert url == 'https://arpa-e.energy.gov/?q=engage/events-workshops'
         assert timestamp == datetime(2017, 8, 13, 19, 50, 36, tzinfo=timezone.utc)
@@ -21,13 +21,13 @@ class TestMementoUrlData:
 
     def test_decodes_url(self):
         url, _, _ = memento_url_data(
-            'http://web.archive.org/web/20150930233055id_/'
+            'https://web.archive.org/web/20150930233055id_/'
             'http%3A%2F%2Fwww.epa.gov%2Fenvironmentaljustice%2Fgrants%2Fej-smgrants.html%3Futm')
         assert url == 'http://www.epa.gov/environmentaljustice/grants/ej-smgrants.html?utm'
 
     def test_does_not_decode_query(self):
         url, _, _ = memento_url_data(
-            'http://web.archive.org/web/20170813195036/'
+            'https://web.archive.org/web/20170813195036/'
             'https://arpa-e.energy.gov/?q=engage%2Fevents-workshops')
         assert url == 'https://arpa-e.energy.gov/?q=engage%2Fevents-workshops'
 


### PR DESCRIPTION
We used to use HTTP (unsecure) for all archive.org URLs because requesting HTTPS used to redirect to HTTP (making HTTPS kind of a waste). That's no longer the case, and using HTTPS is always a good idea (even if you aren't sending secure info, it helps make sure you are getting legitimate data from the server you expect). Thanks to @sundhaug92 for pointing this out.

Fixes #81.