### PR TITLE
Add project links to PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,12 @@ setup(
     },
     install_requires=requirements,
     license="BSD (3-clause)",
+    project_urls={
+        'Documentation': 'https://wayback.readthedocs.io/en/stable/',
+        'Changelog': 'https://wayback.readthedocs.io/en/stable/release-history.html',
+        'Source code': 'https://github.com/edgi-govdata-archiving/wayback',
+        'Issues': 'https://github.com/edgi-govdata-archiving/wayback/issues',
+    },
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Natural Language :: English',


### PR DESCRIPTION
PyPI has a whole list of URL types that it treats specially, and this makes use of some of them. Fixes #63.