### PR TITLE
Rename `datetime` parameter of `get_memento`

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -24,6 +24,8 @@ This release includes a significant overhaul of parameters for :meth:`wayback.Wa
 
 - Expanded the method documentation to explain things in more depth and link to more external references.
 
+While we were at it, we renamed the ``datetime`` parameter of :meth:`wayback.WaybackClient.get_memento` to ``timestamp`` for consistency with :class:`wayback.CdxRecord` and :class:`wayback.Memento`.
+
 
 Features
 ^^^^^^^^

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -82,7 +82,7 @@ class Mode(Enum):
     Examples
     --------
     >>> waybackClient.get_memento('https://noaa.gov/',
-    >>>                           datetime=datetime.datetime(2018, 1, 2),
+    >>>                           timestamp=datetime.datetime(2018, 1, 2),
     >>>                           mode=wayback.Mode.view)
 
     **Values**
@@ -609,7 +609,7 @@ class WaybackClient(_utils.DepthCountedContext):
 
         return count
 
-    def get_memento(self, url, datetime=None, mode=Mode.original, *,
+    def get_memento(self, url, timestamp=None, mode=Mode.original, *,
                     exact=True, exact_redirects=None,
                     target_window=24 * 60 * 60, follow_redirects=True):
         """
@@ -628,13 +628,13 @@ class WaybackClient(_utils.DepthCountedContext):
             URL to retrieve a memento of. This can be any of:
 
             - A normal URL (e.g. ``http://www.noaa.gov/``). When using this
-              form, you must also specify ``datetime``.
+              form, you must also specify ``timestamp``.
             - A ``CdxRecord`` retrieved from
               :meth:`wayback.WaybackClient.search`.
             - A URL of the memento in Wayback, e.g.
               ``https://web.archive.org/web/20180816111911id_/http://www.noaa.gov/``
 
-        datetime : datetime.datetime or datetime.date or str, optional
+        timestamp : datetime.datetime or datetime.date or str, optional
             The time at which to retrieve a memento of ``url``. If ``url`` is
             a :class:`wayback.CdxRecord` or full memento URL, this parameter
             can be omitted.
@@ -707,11 +707,11 @@ class WaybackClient(_utils.DepthCountedContext):
                 original_url, original_date, mode = _utils.memento_url_data(url)
             except ValueError:
                 original_url = url
-                if not datetime:
-                    raise TypeError('You must specify `datetime` when using a '
+                if not timestamp:
+                    raise TypeError('You must specify `timestamp` when using a '
                                     'normal URL for get_memento()')
                 else:
-                    original_date = _utils.ensure_utc_datetime(datetime)
+                    original_date = _utils.ensure_utc_datetime(timestamp)
 
         original_date_wayback = _utils.format_timestamp(original_date)
         url = ARCHIVE_URL_TEMPLATE.format(timestamp=original_date_wayback,

--- a/wayback/tests/test_client.py
+++ b/wayback/tests/test_client.py
@@ -240,7 +240,7 @@ def test_search_handles_bad_timestamp_cdx_records(requests_mock):
 def test_get_memento():
     with WaybackClient() as client:
         memento = client.get_memento('https://www.fws.gov/birds/',
-                                     datetime=datetime(2017, 11, 24, 15, 13, 15))
+                                     timestamp=datetime(2017, 11, 24, 15, 13, 15))
         assert 'https://www.fws.gov/birds/' == memento.url
         assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
         assert 'id_' == memento.mode
@@ -256,7 +256,7 @@ def test_get_memento():
 def test_get_memento_with_date_datetime():
     with WaybackClient() as client:
         memento = client.get_memento('https://www.fws.gov/birds/',
-                                     datetime=date(2017, 11, 24),
+                                     timestamp=date(2017, 11, 24),
                                      exact=False)
         assert 'https://www.fws.gov/birds/' == memento.url
         assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
@@ -267,7 +267,7 @@ def test_get_memento_with_date_datetime():
 def test_get_memento_with_string_datetime():
     with WaybackClient() as client:
         memento = client.get_memento('https://www.fws.gov/birds/',
-                                     datetime='20171124151315')
+                                     timestamp='20171124151315')
         assert 'https://www.fws.gov/birds/' == memento.url
         assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
         assert 'id_' == memento.mode
@@ -277,7 +277,7 @@ def test_get_memento_with_string_datetime():
 def test_get_memento_with_inexact_string_datetime():
     with WaybackClient() as client:
         memento = client.get_memento('https://www.fws.gov/birds/',
-                                     datetime='20171124151310',
+                                     timestamp='20171124151310',
                                      exact=False)
         assert 'https://www.fws.gov/birds/' == memento.url
         assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
@@ -291,7 +291,7 @@ def test_get_memento_handles_non_utc_datetime():
         requested_time = datetime(2017, 11, 24, 8, 13, 15,
                                   tzinfo=timezone(timedelta(hours=-7)))
         memento = client.get_memento('https://www.fws.gov/birds/',
-                                     datetime=requested_time)
+                                     timestamp=requested_time)
 
         assert 'https://www.fws.gov/birds/' == memento.url
         assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
@@ -303,7 +303,7 @@ def test_get_memento_with_invalid_datetime_type():
     with WaybackClient() as client:
         with pytest.raises(TypeError):
             client.get_memento('https://www.fws.gov/birds/',
-                               datetime=True)
+                               timestamp=True)
 
 
 @ia_vcr.use_cassette()
@@ -364,13 +364,13 @@ def test_get_memento_with_cdx_record():
 def test_get_memento_with_mode():
     with WaybackClient() as client:
         memento = client.get_memento('https://www.fws.gov/birds/',
-                                     datetime=datetime(2017, 11, 24, 15, 13, 15),
+                                     timestamp=datetime(2017, 11, 24, 15, 13, 15),
                                      mode=Mode.view)
         assert '' == memento.mode
         assert 'https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/' == memento.memento_url
 
         memento = client.get_memento('https://www.fws.gov/birds/',
-                                     datetime=datetime(2017, 11, 24, 15, 13, 15))
+                                     timestamp=datetime(2017, 11, 24, 15, 13, 15))
         assert 'id_' == memento.mode
         assert 'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/' == memento.memento_url
 
@@ -379,7 +379,7 @@ def test_get_memento_with_mode():
 def test_get_memento_with_mode_string():
     with WaybackClient() as client:
         memento = client.get_memento('https://www.fws.gov/birds/',
-                                     datetime=datetime(2017, 11, 24, 15, 13, 15),
+                                     timestamp=datetime(2017, 11, 24, 15, 13, 15),
                                      mode='id_')
         assert 'id_' == memento.mode
         assert 'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/' == memento.memento_url
@@ -390,7 +390,7 @@ def test_get_memento_with_mode_boolean_is_not_allowed():
     with WaybackClient() as client:
         with pytest.raises(TypeError):
             client.get_memento('https://www.fws.gov/birds/',
-                               datetime=datetime(2017, 11, 24, 15, 13, 15),
+                               timestamp=datetime(2017, 11, 24, 15, 13, 15),
                                mode=True)
 
 


### PR DESCRIPTION
This renames the `datetime` parameter of the `get_memento()` method to `timestamp`, which makes it consistent with the attribute names in `Memento` and `CdxRecord`. It's not a strictly necessary breaking change, but as long as we are making breaking changes to `search()` parameters, this is as good a time as any to do it.