### PR TITLE
Docs: Update Intersphinx mappings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -201,8 +201,8 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
-    'matplotlib': ('https://matplotlib.org', None),
+    'matplotlib': ('https://matplotlib.org/stable/', None),
 }


### PR DESCRIPTION
The locations for the various Intersphinx mappings we use have changed, and the current configuration logs several warnings. This updates to the latest correct URLs.