### PR TITLE
Use the `Link` header to get a memento’s URL

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -2,6 +2,12 @@
 Release History
 ===============
 
+In Development
+--------------
+
+Fix an issue where the :attr:`Memento.url` attribute might not be slightly off (it could have a different protocol, different upper/lower-casing, etc.). (:issue:`99`)
+
+
 v0.4.0 (2022-11-10)
 -------------------
 

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -7,6 +7,39 @@ In Development
 
 Fix an issue where the :attr:`Memento.url` attribute might not be slightly off (it could have a different protocol, different upper/lower-casing, etc.). (:issue:`99`)
 
+:class:`wayback.Memento` now has a ``links`` property with information about other URLs that are related to the memento, such as the previous or next mementos in time. It’s a dict where the keys identify the relationship (e.g. ``'prev memento'``) and the values are dicts with additional information about the link. (:issue:`57`) For example::
+
+  {
+      'original': {
+          'url': 'https://www.fws.gov/birds/',
+          'rel': 'original'
+      },
+      'first memento': {
+          'url': 'https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds',
+          'rel': 'first memento',
+          'datetime': 'Wed, 23 Mar 2005 15:53:00 GMT'
+      },
+      'prev memento': {
+          'url': 'https://web.archive.org/web/20210125125216/https://www.fws.gov/birds/',
+          'rel': 'prev memento',
+          'datetime': 'Mon, 25 Jan 2021 12:52:16 GMT'
+      },
+      'next memento': {
+          'url': 'https://web.archive.org/web/20210321180831/https://www.fws.gov/birds',
+          'rel': 'next memento',
+          'datetime': 'Sun, 21 Mar 2021 18:08:31 GMT'
+      },
+      'last memento': {
+          'url': 'https://web.archive.org/web/20221006031005/https://fws.gov/birds',
+          'rel': 'last memento',
+          'datetime': 'Thu, 06 Oct 2022 03:10:05 GMT'
+      }
+  }
+
+One use for these is to iterate through additional mementos. For example, to get the previous memento::
+
+  client.get_memento(memento.links['prev memento']['url'])
+
 
 v0.4.0 (2022-11-10)
 -------------------

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -798,6 +798,12 @@ class WaybackClient(_utils.DepthCountedContext):
             while True:
                 is_memento = 'Memento-Datetime' in response.headers
                 current_url, current_date, current_mode = _utils.memento_url_data(response.url)
+                # A memento URL will match possible captures based on its SURT
+                # form, which means we might be getting back a memento captured
+                # from a different URL than the one specified in the request.
+                # If present, the `original` link will be the *captured* URL.
+                if response.links and ('original' in response.links):
+                    current_url = response.links['original']['url']
 
                 if is_memento:
                     memento = Memento(url=current_url,

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -815,6 +815,7 @@ class WaybackClient(_utils.DepthCountedContext):
                                       encoding=response.encoding,
                                       raw=response,
                                       raw_headers=response.headers,
+                                      links=response.links or {},
                                       history=history,
                                       debug_history=debug_history)
                     if not follow_redirects:

--- a/wayback/_models.py
+++ b/wayback/_models.py
@@ -179,10 +179,50 @@ class Memento:
         :type: str
 
         The body of the archived HTTP response decoded as a string.
+
+    .. py:attribute:: links
+        :type: dict of (str, dict of (str, str))
+
+        Related links to this Memento (e.g. the previous and/or next Memento in
+        time). The keys are the relationship (e.g. ``'prev memento'``) as a
+        string and the values are dicts where the keys and values are strings.
+        One key will be ``'url'``, indicating the URL of the related link, and
+        the rest will be any other attributes specified for the link
+        (e.g. ``'rel'``, ``'type'``, etc.).
+
+        For example::
+
+          {
+              'original': {
+                  'url': 'https://www.fws.gov/birds/',
+                  'rel': 'original'
+              },
+              'first memento': {
+                  'url': 'https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds',
+                  'rel': 'first memento',
+                  'datetime': 'Wed, 23 Mar 2005 15:53:00 GMT'
+              },
+              'prev memento': {
+                  'url': 'https://web.archive.org/web/20210125125216/https://www.fws.gov/birds/',
+                  'rel': 'prev memento',
+                  'datetime': 'Mon, 25 Jan 2021 12:52:16 GMT'
+              },
+              'next memento': {
+                  'url': 'https://web.archive.org/web/20210321180831/https://www.fws.gov/birds',
+                  'rel': 'next memento',
+                  'datetime': 'Sun, 21 Mar 2021 18:08:31 GMT'
+              },
+              'last memento': {
+                  'url': 'https://web.archive.org/web/20221006031005/https://fws.gov/birds',
+                  'rel': 'last memento',
+                  'datetime': 'Thu, 06 Oct 2022 03:10:05 GMT'
+              }
+          }
     """
 
     def __init__(self, *, url, timestamp, mode, memento_url, status_code,
-                 headers, encoding, raw, raw_headers, history, debug_history):
+                 headers, encoding, raw, raw_headers, links, history,
+                 debug_history):
         self.url = url
         self.timestamp = timestamp
         self.mode = mode
@@ -192,6 +232,7 @@ class Memento:
         self.encoding = encoding
         self._raw = raw
         self._raw_headers = raw_headers
+        self.links = links
 
         # Ensure we have non-mutable copies of history info.
         self.history = tuple(history)

--- a/wayback/tests/cassettes/test_get_memento_returns_memento_with_accurate_url
+++ b/wayback/tests/cassettes/test_get_memento_returns_memento_with_accurate_url
@@ -1,0 +1,377 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - wayback/0.4.0.post0.dev0+ge2af777 (+https://github.com/edgi-govdata-archiving/wayback)
+    method: GET
+    uri: https://web.archive.org/web/20171124143728id_/http://fws.gov/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEA+1963LbSLLmb/spyvSMRE2LBHWzZUlUByVRtubodkTaXq+jQwGSIAmLBNgAKFnT
+        xxHzDvtn99+8x/7YiHmUeYF9hf0yqwoogCBFynLvzNlV2BKJS1VWVlbeK+t//8//tffi6OKw+emy
+        LvrRcLD/fI/+iIHt9aoFxyvs770olcSJF0a213YOnJ7ricgZjgZ25FQLVlN9DK13/tA58P1o49wJ
+        I6ezXu7cRQXR9jvOxTgK3Y7zrnl2ehKe+u0bp1MtdO1B6BREqbT/XDzbe1evHeGD+tkbOpEt2n07
+        CJ2oWhhH3dJ2IXu7H0WjkvPr2L2tFv5L6X2tdOgPR3bktgZotu17kePh3ZN61en0nIm3PXsI8G9d
+        527kBwyneuHO7UT9ase5ddtOib+sCtdzI9celMK2PXCqa6oxRkyz7wi75d86YkMw1JHdC8WfhuMw
+        +hOgGDqi6wZhhCZEhEf7jt3ZFbZ3L3x8Dfi7BlbQS/KdP9ndyAn+RK+EjuAmGVHAD/XafHfSEPhX
+        E5e1q6a4OManRp0/nNcbzfqRaNbPLk9rzXqjLBoXZ3Vx+K52/rbeEGe1T+K8Tg9ciIM6vh7Vxcm5
+        uDivUyvNd/iDX1fJ+7hWa4raVT3uijunbsqCBq9pIcQQ24Nxx+nIsbqh8EAIwg6cHRHTBhHFavJV
+        kgpdBE462etMQpJCMPDnTB78a5Ik6x03sjHzQs4roVnRlkJZTMF1rxM/rHGatJw0f1X/9/cnV8DU
+        Wb1ZO6o1a2lAHgSh47cjNyJaRC9ijz/vvy9jQo7dsM/D/egOOgO364iGExC57VnyqVTbefBmx8Sr
+        Mh6VRAERIxFOggZ6i0lUPnDkhO3AHUWu7xnrpdZzvPa9GNqe3XNCcY4F5Xv2QNxpWAOnO8adVTEK
+        /MhpR6FwvA6YhRNg5sOR03bppn5/6PYCO/KDe9Fygw5uBKAJH78wUbLlwb0I3Z7ndt227UVYLSHW
+        BdpgDDle1w/a+NJ1Ok5ggjGw78JyQViSK5jjssdR3w+MIc1GetIG8bnCqQ2avcLqd+4wniMwuQLo
+        uQPgIoBx13doHYO2R0APBtN23Fs8Z4vueDDAd3pPQg6CFJEP5ITjwKFVPRq4xEGByagvjj82xEen
+        JYirdmxgphyTlzmWSWh2jIFV3liVdWu9sraVDMKY4NFOxx/arnd9C4R2740X32ysrW2/qbxprXcr
+        9pu1tY3trXZ33XY22q/aW2vd7YJGq6QQEd2PwCwj52tkfbFvbXkVXLA79kDkvifOzq7DO3t0Muxd
+        yfktrojfhGXdbpQrWFK3diDc1a+rdhWrYjwEYy7TG8GuwPQW3Wpl115acvfs8sDxelF/aan4tWp/
+        dn9ZWVr6WvYbQXvX/emnFfG1HAbtqrry/Fuq+1HgDHy7czIksp3svRP3vCvcbrFTdvnBld/o24sO
+        gTNaEfJv1cMc1oLAvi+u7DJDkPB/qcr7CkqMht4y+y3bQY+HFyYjE8m40DWGwS26XVGkEZZBW87X
+        i26x8LKw8qJaAUCyk89ffmE4eEC78cWffvqFkUDv7n77BiSksNBFcxetL0VvVXTUDGyWK2tqCkar
+        mIRdIYeM0aZxUhxVvQScnwsrK/uVpaUR+DemqxtAXoZq5GiZB9Gppu5+9srhuBVGgev1iqOf1lZ+
+        Kevp3hUeGk/uVlZHK7vf0AhhH5Pd+ezRZHfK9mCAeQai8QHXGI2CKeTFVyKRThkUM9SAKLLA43wV
+        OKF30KwmK3qpUx7Y904QytflZzUQ/T7mMcGcfp5mR8PPdECwfhVLS5iMnhPVBw4R8sH9CTBNEKev
+        Fb2VXfCDaBx44utudp7kYgGpTlKqu/qlWuG1QkuEFxWeMylLAyXXUEKtCc25e0W9lkrrKxhldYPJ
+        jqgO2DaGy6sMhOeBfa38lm758xdQWxUEwwPndUhrkNYjFiGW4q5akWjkp3WQI0YJGSP2LMkgFGsm
+        tqrVxzxhxtKufn4kpktcfoR0SxCXPUo45cD1bkQfEqla6EPVslj9tOwQWmNotcPQaul3ykPXK+NK
+        AXMyqBbC6H7gQNA40PwM5kYPKDWTR8LKlhLOYNX0zgKdk9LT4Jfm6xn6Y8e1AVw7cEjxlsh8cIyh
+        VB6+vyeaqD2jO/4IEXbvjwMB1EA2kzrzEAKzw4gxJsdDvZAlsCXCvjtkWQmZMfK9TvkLuvADcVLf
+        FuF4RHq58LvqYUcuN6kWMKLEr2OpKGgtjqnkY+3q/OT87Q5keNxox3dCbzkSd35wA2KmAQkW1KSR
+        syC/dSHBMbody4rBpeY+4+lBBIjEm1/UfCiRSJKoQCZIiHf8MCwP7a/tDmjMH1pkQG1hdLfWRvl1
+        eT35zlT4BTSWWSJztAmViXBkrZU30aL6Nq29F5+hk7ndX0jzxA8jXmLf7OlLaH0hHN6X1svULC2R
+        SeDiWWtENibkre/3oGbXoBPeR247hGbTUTqN4/VJwekIJhw7giBojUk9iCdI9W6suJQ6EcMqNYbr
+        nv2rqAr+8x//IT4zZ888MxqMYZC+DwZ4kCEVYtmy7u7uyj0GtAQ9VgLKMyMfD62ebbkezfw1weoS
+        6S1LUa+wxb2WR+OwX/y8fB2QmRk4y6tiOfUaLsQA/KJ0BQ0GgR03AIZUa7f9sRdRG7BV1yuvK69f
+        V7ZKa8v6RQV+9r0j1uHOIX7p1S603p5/O/Ml8Mj2zSUGRzSefbKodTaSPNyl6lfivGcDkbEYACOC
+        2qskXXFZTt8yBFvPLtMk4tnljFa4zDft8N5r424UjB2J17gXvIq1g3vFZbl8lkXV6HLgQ9MGzZTJ
+        vPDb/kD8LNSDlhWGg2WxI79j2WGal1fET2I5f7LRUzytcfekyoXmGBOxHR7cN+0eYToZ6ucKdJCw
+        LPWcc5A6NCQw3OjAAadyij17VYRq4lUX31a01sgXMisdPAUycMoqkusErzEnI+P6yO3Brh0Yy+0y
+        8GFRDUXxqHa5wouvLPBRwCSBxwQKCawkwATXCRbiHSyMeAEIJSiYx2p7ClTikcVWFpdY3W7bJQ+K
+        1xP6Org98+F0SxAKcWfCloQNMGBvim7gD9nTgfljQAmwQehrkEbj1sBtw+izyeTXa3Mc2kTWZaG4
+        757iFC4cRdeA9dr2rsf2NezZlLw2uIdIMWRiAGqpKGUEvC603nuw1oIQnpxjtifhpirFnAzE8jMP
+        +756dHGyZA9Hu1BY1ZX3DVhsBt9WbGLPko6rvYOLo0/C905hglQLWbOguCytDYu8YC07sBrj4dAJ
+        /C4Zu8A2Xx5Hke/BlnvdtcGORr3lFWgAe0cnH0R7AI2mWiCXFqw5J1AuucOL82bt5BzOmpi/dtxb
+        /fQQdix7QZQ+A765R7cJowO/52s9B9ef7dlaiVLyzEAfOnOHvenYZb0LEz3qQxhY1PJ6pbJV7rnd
+        AuYdDrgLjLIN5xmbuyxsIdNJ8L4XjemukIJo+QFM/mqhQrbtnmUb47AwEOOrHhYm/MCG4c9OFIyS
+        lENQqqIDQZBS/xjRw+OVLpIWvKA3BTl4NYV8ieanAEOePIWFtQK8eG6vj7HiI495RtcYyF4G/nBk
+        ezwvoRs5xH5gqcsp9/xLGFORmnCtROd5e5JXQQwzx6fRc+gTI7ulxU6zAUcP+SkwNzWQJtwdhf2H
+        nqBJYU6lActo92B9GJkxUaT6nfKsoMMGBote4SBtQVzRRBEYNI7lkOdKamaatknupzrLw8JFwOyb
+        XV6Sh5Kj9F2tAV9n/RwGxtnFB3j0ajA2zi/E6QVcolfsDq0flcXBJ3F2ICqvrfVt8qm8IkQSxNNG
+        R/egHtojOHba5HtcFXanI7VlP+jZnvsXlmTCAhPtkZcEji04i8H+mT6kf4gGDVY5gi+YeCwvkNSY
+        NXWHjh20+0zgWeqIhRvDe+XANw8/0/tGjXgqnIv0InH9oaGsEaJL7K7D8oRoSD8DlzdGdmu7AxpY
+        4puKZwGNv734IBr12tXhO3F8cXUWcyF6hn72uEdIB2cUlWJf/vvmMXz5EBok5BMNWgJQVnLAkl/h
+        eQO3kp+vqbUCudj7Pi5CahscTHaoOBzbadXCEL4Y19tZq+yOMC0g853KbscNgZv7HdfDDJgxAd3A
+        sz3od+NIeZERdwCoUlvtu50OjDK4sgZj+MKWXn5df722sRs73nQL9DezwCXdXngiHMKrIYZ+C5aG
+        kBEGeER9j1ygff9OzwKUZogCLAeISKKUkBaHmqEJ+tD9MnNXhHHrhhQFKX2FuQuGBO9qtRAQh8pB
+        WXrEDaYDPWYJSAEQHoLEb0hwKOWMbe5ELeO3MpP3M2Gv+sf6+h/fHP7xzQbLUxuyAF5QBI60Hhsj
+        VPYMoiU5K23teA7h0fXFq9FXsYn/9CVnHNNwPgAZYG3F2GZEM6dRJO86A/hvsSgV2ulj6LPEciFy
+        KawhWphzPQOBf2euzzz8S1oh9CfML35OEhgRdoyNgqI340Iu0Smk5dMcVqozoFVeLbBRJxePtO+6
+        NMgYq3oVeD6tgTriXoFmEk0nGBbDlZ09i5ubCj5NQptc2g4FAaHIxCILKxhMpyTJtWQ+ZwCkB6wA
+        TezB/KGZaxK9Dt3YawMFjb+pVanJV60DYhkKktyGn8WMM56dRBb77ROa/pwppIfzRSzYLjxON2xq
+        jkNMV6yMSLHnC+C8RL5/Yr+4ScQJveFaKRrsWol8fxC5I1Px0uojk6UlqfO6q3sbeVBGWO84VpcE
+        US4aMLUmPcRc6CMEJUAGCeAWOEcKmglYlZaVOzBDZ8wFXXV3TTGhcgJ+U0KxEPTSDCx3iUFJ+Ed9
+        GI6hxfjv/6r8VRqpTzMM2dv1xrqh5x4TBFhJi6BeAQ9/VDRuOQn2fwjQimzQ2TX3luD9E/xhTQBg
+        wK69GCbVZKgewMMWhkkGc/QHg84qGPVzTWsSeB8ZVBPflOBr2aGkfokFH9SA0dcpC0KpqekRS3GS
+        vUYMRSqF5K9+QAeSTbBKpvQZmH6xlmTe1bYa3+QXGuMWGW/Pqwv/JB1QA6BHxQu/jIctPwqgV4Bn
+        0i0RSykwJWlmsLqFVAZYBc6dwfhM3YLb4UVtPkC68J/jyCC7UtnNAB+O9Ce0bA+Wq5DcIK1PMkPK
+        +CUDSGF/eMIxuoPGBrslU8w67VbhJhKras+SY4f9TICd27fA/GNx+cwcvcdNQVxTiyXXI28Ccg60
+        mRaDaL4DipV2e6k7GLsdA20MNun3WqGXzUrgC3Ddxu3JZcij0XoksKmUmrS6oqS7VFvIslJ0IPUW
+        2RB+Z5rG2mbRl6NBsg7+RNIwK1MoQaJaeJQMeVD8aUYgDYFS5I921kdfWWP/DsHY/zVHNH7HMOYR
+        hfkjIZVmvoEsLCMfM54HZeITjeJhYfkY6OcVjvmDWICo/sml5ryLJevb0XzFYLjinT1sjdn6ivwe
+        BY0gPpUNrDgXfMbSIoevmnQJEkvkHUSiibJ8c00tbSBzVoo2UtM8VPWI+MHAHoUOjJ8OvNNgAgQI
+        +VLldX1Z6eEvFWNPbistt03KHcOPJ9ye9Ouwba40b9Vfchfsm+9P8FnCVIrXksJYgjgh9YQdZpO8
+        +eF3HtHNxCt7lsRlyurL2tXSmXEu5SCPsCwgktJmtjmDCEQg2CodEpTrmfywkCTpMoH19Fzq2YD3
+        Ss1aqhlucG88MKSoFtBoWH+U/g/WcKRAJKGTZ90hAq5b0mAPepgb7TPmhJ0yhXgL+xThZy+oNXBz
+        YEpaMt7XMWPDx24hWqsy6KyfKZsBsooJAg5VnVnXkJl1T9Fbf4zsvLY9osiS9cVvhTyaVMd/xlXq
+        Cq6s7xuZyhZMDytOKowTIK9kUuFTjA7JW2GmO1wJfH/4FK1TzAb5iOkOOMThMMK+F1/wA8OhkWn/
+        Ul58Cvg5XCOFHSdRwIRD/tkkATSkB+yMMlLm6tfzleIJxhevlZdDBElj15DxyBmucyhgFtKsMbLR
+        E3aRdasanEl9fPY8paxD4zWU7ZjbnCGIdugPYrDAVUrDToli/aUN4jH07RXefPYMajKbEAf1t0iS
+        Pq7Xmu+RCN1oXlydIJeaZBPLuz/hR5ycXV5cNWvnTf52eHH5ieMMlzXkY3Ni9cbVEb/6SVDkrn7e
+        ROI1srAp55qc6Ccf6uxH30EavswqQeQHdpCD5DsZ9LeYtHnCuojLI1xTbneHkKEX58tNcYyYg8Mp
+        pxSFsMXpyfm/keMYYYb3mOOAwysFRnwDGbiUYRvHaomPIQCM2JicFPg62T+PDO939fNVADwxmsP3
+        V1c0hnUYwoSQnFElA65d1WuptmjQZwheTns1aZVeRbDbp/wd6A9qiMh/cf+C3HMET9ikpIGubcHG
+        l0G5F/SzQoIJcRAojKJvI0F/CNMWmIELnv2/EgkyaEMXKOuTYVLzLK3U55ICzBsKaM7jfVVRnSpA
+        QBNMEicymT712uEFku3f1pvIwq83GohDvb9cRQSlLkxRwAvU+YroM5LNLKLVYznXdXmNl2ps5MvV
+        YVqbaaKn++Zdou6vYWltncn7mQTV3NqRSSI3+r/moX6U6eT8IlNF/UP96hO2BJy/FQf104uPGYWN
+        H2xEzkis7Qi259nXDunDecOZp3k4Eigy/cWSOFQPxkY0FHA7QNI5xdLkBgRJAOS21632fMCCmFQ9
+        nuj7OLNAYizGiwoWaWcRGYmCfEXQ6P8C+x68sVoo6Q0fybvyE0HahDRteQiUKUIsclR4R2xto5UV
+        mexNapLoIQlNQX1m3yCcQOFWos3xCKqppGU4cWmzB4g3M8NJzzybKqZD6R5xOgDTPP0SoL1PF+95
+        z8bJeaN+1aTJqYkPJ0f1C/yuIbZH2byr/NTZ+0YTujfv3Ej0no7jl2KUQ8UFcomrcOY7q8Ss4SET
+        R+nHH5DYgEg79PsB6fCU4n9fWKadJbxbhLIYmrW3MYj4EDPPZGipT3sSSB1k33y1noTZNyjhfSLf
+        wzQMnWHL6Vi963P31y0/etut/Hw3RPJO1R/ZiDkUwPmAACPDAEzBv6MUfvihkHsJTVx2vz91HgjY
+        WM5pjs0LOd8T7SGbEYpnGFmbaxtrlTevtipb8CRkIgCG45wZgeLzFI9+bZG21BwHN859yY5KHwHz
+        jQtmdv7x6hDJPm7EsTOZmsDRAHoefl16ASE8Af8p0hRFnLcACk1Qurn9KhaIyPcoRZqssRWA5L8p
+        h9U8GfI3NXOEGEyvXOx6/cbUbyKUBGyKO8nFXthXQCPyxtsqtEvLjv7+t3ycKwEptU3rTqHmOqB0
+        nxwsJ7hjS46SU/T2FqmJ0pDLQqJ15+9/Y8xm9Q8adA4OmH2RRq/YXQ4PC4n4JzDKL2pWSSL63sRV
+        jGJ67B0WGZiKk/9Af3P/1In+8df/EYqmPbhRJACn6ObkNFJryNuabMmcF3qgsH8O8YllFYi116uC
+        CHLK4CXoLb/D8Df7/hiRZ+bEHOmG3kIEGSIZEkZ/CL7Y4twJ+fdnpFsIuPawSUw+GGIrEbglSe0b
+        8OOQ/AP8brgjuoP7Use/8wT4Dn0ejyAC2jcDZ1fcOA7/D8bernC+thFuQ2qGMxgxLyO1tMxzHvdC
+        ZqrnR9AUAvA58DJ0Jv7x1/+m84UHiOuRT5U0BbYlkfmJaFt5LooMc2gwNoLuNOkpW4lo7+9/I3h6
+        lH4p++EcAM5ZpsdjqGngBChBBdOhC7VN9JFlWhaSjueEDnqmOwiVLQCdcpIvySckaEgZpL1YlMMH
+        IJG6QjEFL3DhCQfi8BHZrrwD7F44t7gJ3tNEZvBN2HM53ejIvpcbqeSA2TsAcufsRfjTwfIx2YhG
+        tQc+PDflvVaQpts5WEBoYU/mOLKOx96Fp9e2REnIfPQaodIovOanriW7kWbw5NCFJOilAKLD3yUU
+        8ErlsBP0y0zS0+Sy7mfBTwIVBgvhNi0KK6V0Ri0m1zHJUs1mtTPWdfPVTnoaCN0AKWuj5RHKZ8OB
+        CoDNafd5GmiG9ZjsIquCmvdMBTRmacRIwYfiTKu81C4Miefhmoe+qBoad8X9aCb7sD4qwfqddFHl
+        9UpEb0z2mqgInGkKJ+Pl+xROxpLuS6JMf5tYcxxej5WaMm2eCMvYYNHBhjioGW1sg2ClZa1ibaxt
+        b25sv6psbq5dt19t2VsbG+22fe1LVWURDeiclagA7lK/ddcHT5cSGgt8gPTlEHlKB5clXINUv3UO
+        kSmCBA7gxdCJdAtCt0Bss92HcACXsgWiMT2OnMEZIHX3EVgjjGXN+ilXsReQ7DI0KXSRaFJrFXxR
+        U/mgJkUTOoeixHORWkZaU5oYT/m50lpIvA0oqxtosQ6xj9weOSRJD8B94yRyjSuhkLUyRaYLVmi0
+        Mpe12uRLvFYWVXz4JV6P6zuK0U60DhxNVXj2oNQggwkZxiqP9R9//e8UzIbdD0XhLaWXHvDGY6hD
+        LPrhXMNgxwEk1IHKO7XFGZgcUn3BLe0AbsKsokRALqwkbU5Vkk6wE8mGQIfMRg4axOjam+2K2lt8
+        4LdEY+QiAxfjgT4CZyNJd6gB9DhoPoyg+PWg52ByKVSCqzEp92F69ZDUhewibKTF5imprnTtoYte
+        uhgbXdKDZQWxDovEwRbFBrZMQyV6hwoFAI02SqFfFjXZnQJs5d0D8Hgzt0Y9Y5Cw2CLo6Spn9pJW
+        9YUqGxCsv47JVEacAYut7+MixkA7weGegdjn3fBzCPwM88ljO2tWZQPEKCkD5oxTGjFZlPxuqQey
+        KPF+dMRd2jeICpXsEiJfTAMlwlOOvjZFDcg6QWoHSDEGCccSZyLUrlmqeiL1NfWF18Y8akZ60ZJR
+        JVUMuSJJp0j8aVqhYOVghkaRke8pO+0xAh6jTY0nT8ZDX/n/Mp6w9H9HxkuCnJD0M5waSIbYeL21
+        WdmAeH+zCfvBsget8bD0en1t6/Wr9ddvtvBvG/9z1pOxrQTeZyvl6TikQF/PuaRMvosugo33H5Bo
+        io3oTX945GJzb7svpRwb5mkJr94VnAZI7IVeF+p9gQYQc+YWVsVZXJyCZAQEhY/9K+Cw00T79ubv
+        KdkJ7FsaNnaHGGDLnV7TQGfuTIz20m5TSQ3RgBnUv0NRBliEtAmhvJDXChPMe6nnmdAGTG4yrDXQ
+        nDlNoMyod0JeljT3YiKUjIt8KD9U5dh4tMpx4ES8TQ7iFJQVQm4ORqGotfsuLF4WdA25K5uF7Jkb
+        hkD90ygWle2pikUTyDb7PYR2EbagFEzOgAxZmsKerW2oCSz0adoo2X8gF46NNPhatwtNOCQ9SlIS
+        bqpWKGWQB81qATkB7pxBm2JKsgACqQKKksm6R/mTNjwHMoENVTtGVEcBfgTaaDimSku0HRFuINq2
+        wVECNAjXJRYmNaTh+/vfKDqGPGraWcORLGg5CGnDbYbn23A1UL0VJGF04emm8SjMwLPgOV1SA+Pw
+        F1Lw4HdwI7hJpUalgaXBhuRkDedQSswoDkfqWuAmiU9FmUNr1ralqKeEvA+intKBgqikCKVEe4Wp
+        XkzYJ9TM45JIKQ6pL+Jh/8l86tQbq4tJQ1pmiTxMQFgJrKXj+0HJ+QojysVGUidEuj3vKYPGBedN
+        6a7vlyj2xpfhkc8ZyrFsVLyTje6IC9mqqCetyrnD5MObCC/Tx76P5CIsNJpS6KmGa2bRoc8WbnPz
+        PsGiCvbGYID99DvJqlEeQ017UyFV2tEP1CZNPTSFpZRaNsublWbUeWpmEvElNVMGx2tHRyfNk4vz
+        2qmo41Pt4BRx7pP66dEqViKiLqtKZNHEUg4YlRBQxhBFxzyQHC1ojuDaYrOJ3WZGHP5TGf6yf0NM
+        ngLzFPU6OT88fY84K61402JmndW8YHii5MDkbzTQQKCMw/IxvByEVoUjxuTmpApQvKmGg8QpDOYp
+        tvWv4FXKi1aDe2KeIOrkHOUSB+vpKQCyUyingV2LJuZ0BoO8nc5woE3NyB9AjsPF+eknTiVopM1y
+        E5NZcwC0bCQ1G3hODUk9lQnADpxuxMn6u9gKydv2OHF3m7L3M6+jgaxrlZSHfP1VBYhk+ouM/FuF
+        /VQ2xIy1OclDuSfknCnwwaqjEn8ucTh6ZxwMivGu6BYCi0506AZt7KXEtgva2c16TupXahLzqOgK
+        1ca8SJERpa9dY78xL7RUO/iCHLYkYS0VnMzDA4e5KZXk5XYFeS+P1G1oX3NerlhmpI8HbavwQPk8
+        khhwP0AbgyghVYE9OnKLvbgw1QsqPrBWoT3PUB4mo39Tk5IyY/kOPG8W9o91pQQU4rshzcMWCLHB
+        4QMHEDSh8A6FP6Azarw+Xd8b6BsbWaB/TeqFWlAdodxJm4IyDaSj9UWHC/JF4s2mAVAWoomQpnrg
+        ucqiiv37+RzqKQUF2yFwm0kHGAkVKrInNsVV/ZCyljQjTBgdrSeonTOECa0povBcCcESjVIuKLtC
+        pnU8Qk5MrnCWHMl+9nm8QcQM9rK5c3wNXDnNeJREf/ZMi3biQZYgj9EkhhJRoJgOMywtOI7qV5Dw
+        V0iUQ77b1fcLC81ZTSmwhj3AGda5J6t+6lIMlcofYxNd3uHfiBdQMQmkgafHz6iKAtHqQUrRztmX
+        9aPjN8f1nMfko9g1pUo9bG2gI39ACdvVAlbUHkqT+V5vf/qSkiVHBmw9kdMVq53cu2A26tXseqIu
+        06niIwgSuaENHcZlOWI5c3wVjKWE0ftBXeJuV7hIm0WO428i9+VRYOyqQ4hgBJWsE7+dupDfgPRX
+        G43IEVLf8tO0XQM8UCvq5MyOFVH41CC1NeQrHV+JE1S4zfooJcIwn0oqJ8EaJDNhfndeHh8fz5hb
+        RUXrFZpOTKwO46TQjhUSM7JcKQ1sN7Ez4ZrjOkpEPwLfKXUgwzEXxyNjGAhOjUvmdaQ6mjYielSN
+        ZW3NWl+31l6XUy9mIAQH4r0MSKLFT+rJaV0QBwafbtL2HY02nXSf0mFkKViqqUHLiGpcWLpiVRhb
+        2QCR4o+l9a31V9sUlVKJ9CgI1oFxyoWtPJT/0VEHvo6UDg/2OJoeD1g3CEvIaSuhMG3H7QADlBNH
+        Bi7fK2Hnq8M1IEO0EvVh287YeTSR6QWE6dx+NA/LVoOU5CLR9UsGaZe4hoaJDaZDDROiWQlMohbD
+        hGYguGsh8gzZpHq+cObCQ6uSZ5Xtiuya5DtSMlDk4QcsVxRUpvgUF+B50vWKNEMIr9z1OoO9pQg8
+        sxT0SmDulPmFis85TO9JFqscyO+yWBXOnmaxvrbmW24luAQVaZdGPpIuUeB4oQW48AoSl9zNj1xI
+        2dViLCTyrfyAhfSj1hHUo/8c60gOBOsIGbg/WOgpnD1+HQFEKfQ237xGOA4LhFg/hbzdIdmUJfhp
+        aXsRS7W/uMOW3bpzSiitOoKpFJWgwaKMG5y4ERJFPHJPQ/jxSQSlL7Y3hmu9tL6G0pWojQXpg/sL
+        rrj/qnoUqCjJPYqm6hGJquiRNhLC5KzR2QcoJ8A9ivU1jne8wkYNiEP5hKy+KI7gEOGM1A35zPbj
+        liZ0lTwujKtQPRMhl12Axtpkr+S/jk6KMOZ/jrUpB0Jrc+tHr02Fs+9Ym1t6bb5G0X7Hu3VhL1J4
+        B9UoIcqQNEdfeGFRSi/8V7RuPb9knI5Ayxh5q7x84eAumSu84yDzDkoqPFoLLsu6CQtpjAoW5T9j
+        WDiQ7qNoX3JSwwnDEgecTxS3oSePEljEpWQ5/NyRj+qfDmXoQXNHcBdeKB/aaRT+0IVLq/PqOLEY
+        nz4uMdXddFxP+0UYiMY0NxPldHHcAowHclkaa/vCidqIh+aEJeZyOsnRasdRnvEloxNX19JPQJyB
+        bFypvm9RvOXHc7Y8X8Zsd0Q+zybNOd+NAnQSn9gkPjElRjCXXbm2oZfxJkTsYnalYXaqg1IQM8BG
+        TmVlIgUPJSM9WtioNxzcuyUUK154LS9kVRpWp9pgjjQ3gkjamAlEiMYQRHSSRxmHsQQemZ+eLYoN
+        uEmO5XdffKD45z0lMCLEjtieE6zEKzsRpERTxnpM54VljKesT3nvIe+O9tlM1uQxTS/Sek3vXT7N
+        PG18h8My2jVlBIzgZuMkBlSlpELA0/xTeZLHcFSwG0RW3btywvEgCn8ORqPqVmUp9KtH9cbhUtiq
+        oivwXfLlLI38amWpPapeLNlVFKRb6rSj6uXVH9cPzvH/mD406NfFbPrbv6DdH4fItIbsIlbv+p2p
+        0RM5AVRfYTJqNoGE3DDew+Nd35o1Xhrk8ZUc8QMDq4EXJw7Tf/IxXc4/ppQb9598WOdzz5R0Lz80
+        nJygCNFkviiR6n+KaVgcTEg7qZFdA/d2zD/iQEo2A3fC+w85mzA3/ZrqLhs/nyhPgIADeVbjbjWY
+        5osy4wGiHAXfSvgi1jh3ChkpvH8NeTmwp8AEx8P4gAbdjP5rNocn463j+r75F5n42KXHtWb1vuS3
+        yPy2xb+Poe1BK/15ithVIenOOERFEot3HbchgWij+0TJUl24Fz7PCIqweM9TTkbjISlPMdOInMHO
+        Wmm7UiltbG6W3mwiWrO/tvRye73yZhdX1SfcU58+npweychmNvdfDzEzQ+nLJNssKqyn8Exzq5/Q
+        f01cxlMTv7OeG8ugd8334jnIKTmn+6FXSH9rcLFhXXfPOJrviioBy9lHfRxdzAh1ccfYWEjb7tgR
+        jQ3fNHkfT44grXE04MabLVRXKMrwF/L3PFIFsK3+yPZQr5tS3dQGeGTGrG0hX6O8gsIUKLNNZS5k
+        Sg5nRmBvwl+Q36PyopTeh0p2sgAgyKQMVzjagF9+QLs+QbfyPeQAwWygqg/YoEBZQdgaGDd9eFpr
+        4ETE8+MLtGyeQqj2x8lUI1E09uWgMRyoEtLOA9qmw3t6ECBE1QjuHyBAHtMefVuoe8iIxB5QWjUj
+        WbAbEQ7adzJZzlDPBU/ELNX7AHg74NKIIdvkCUeIm8iT+6mCIIR7MxzI6AqTswagU8guSFY3ALIT
+        IvOxZ2yKkslrsNsoeMDJlNh7QjW4yBih/7TBAvtt6SMLfNkKzzrcMghtYJcxsjD5UdqeSnpMOQ7E
+        Mnrzsa1K2E3q7Nnlw5iUvDZZ5amokJnZ0rIjM1KDTJ/EoZ9Bz4EdfXScG3KbNf7dwAmu48QC54Z3
+        OguYQzYXncAGYtofguzHVdq3Agc09sG+WGCoeaxBz7X8Kw229LUHxjwOqGK/58wa6Dv9kCzyZQyV
+        75CjEPmUNnaLiXMUTKJDTxH7GsKhgEW5CrXap9WA67QAyOBdZIJp1JORwKyunxkzf12A7+bzUJN/
+        khSMDQMiKc2yNxZjv1N0dALY7E7WkKBYvCkWdZSCykDrisdd8DMQKfFtVfdiGp3wM9I21y8fU4rk
+        tOc1Tk24VM1J2lRH5UNkdYPmHU5DC3cmF4osOq3e4W1TJYwHIqTVCzcqRrSfs8HppA8NGBiTH4tw
+        lcixQ/VyqMKK0B8oPWDKLGvgGbFZRqgg4q2m6jNqmsVLUQMcuUMHW+aQAYFIqjzSWNYCRPQQ1YRK
+        VIBuowLFYOPV1ubG1tbm9uar14hoyYfafWRpoWCg56N4B1VR8vwuzpTDB84+h1UMw0dXEewjGkzn
+        jgA56hJKaMPYQg8JgKvqY0F8HQ52EphU7KqJUDI1L6FDKQyeFpmrbrMgYjbLc0YaS5ZRmihD8gif
+        8Lr/Ij70qbMarrqdld8gvMWXcLX7JUydXGgcgRSu0NlH8nRM4EkdAkXHHRbRwMpv/KbUFfQBUTgJ
+        6UtYBkLdDn3gCi2WhaB6RJykrAbOEyaHF1Jh310AMfWAJQkjzor8VtQx/lU6IA/n1hZWNVZLd2hm
+        BVvz1XBzccILh6PVGsUPrhtJlfJFtS6nLbMpBJxqYTazMRfoVD61ObX//IzbvdF0AtEVdljJSqi5
+        fQ9qxbFdk0VygF3sy4LCUy2c07o2T8CbNclWF6/5d9dK8FDpxJ/RFlSNaz5mh7cfxHxCapg762AP
+        +uQOTgGm78pmF9XCMTcp4KiCvFITOosr63o+e9YUjCwygZu53HauCdzSE2g+Hav1xgj4PvGm4T22
+        8fjIOh8g21fpr9g+w1dEOGCPEZMo20RgdCgJwvaQegRq3SWfuSUTWiZA38MRa5lmqfAVHXjsB6EB
+        ETNhklCfdFq+LXkkA8GdOjYOmjF640TIO7g0KYNfF5lSqr8eQ5ny4HBEOCmP8qh0BDFsOTLa6+ah
+        vhal7gk6CQrniNFzOB0JZ7TwjaS8G5+uw2YDjJg1FKLCiZWcAoptBAEdODOGaIpQkHyAI7iBIVVk
+        DUZE0sZrE3roOnFnBky6i8KrQp7mT/4tehpBVHm4w8vUDPItxhiomk+3UsgHgLBFoARwFvWe5RvF
+        D3l+m/6oNKQt08UPspzqigksVFRNJ6JoTMGKNJ9COmFGGXgbb14JWSkPO75pMg9r52yoyUPieevD
+        ydlbcV47q5dxfLxRKAwl/3ARRyZ9xFPvzw7Oayen0GIukDfbxDlAVNZPFwaM73M7osibPVb0AW+J
+        mEotBEXXIEA+52yCkZsPo/wDjg/VWIsjCEq/1+RlHS99JH32uk271AytdzJRkx5DnTT6g3R9EsIf
+        AxLGOP8FpW6g9daopsyMpOk69mz59440b1VRUBwkzZWOiJJkvjn0ZsNhlCAirTtq+JF8Jo9on8HI
+        s5qRuRNNlhG787h45KjT5fqBoDL4OfIxMLlLMQXiaD+Fobs0hriezgwMOSaGfFlLFVWEYgzBpCIX
+        wFQuzTxomtYzk4VPkhKxspraYgjOYKyZx62lCc7KwBpymQg2xxLVM20d8DYRnNeeJdUmaAe2kk4X
+        1JEa/XyaZuHgvXUpfIwsVWXAQUTin43wDHbpyV2OF6DHwGyU6DsnGkRRXWzH/F1JNgmqyYqncvsM
+        DqeVRZeJdB/AyBw07CWrHN4chbHY5NUYg5qsMeYzxhLYmCMkET2hInpCYez/TRKWJbbec0XLCTKW
+        N4W8+7tSlCw0FlomeOQrASWlgJqDbiQPB7/4qMu2qRYSgvqXnPpJ/jiDc5HjTR8qofxuDjgpCtbK
+        P8iTTgvbOt+lQ7m7A1lamBV3kkC0c5hK8iRJzLmkYUp+zTEfkI1xNGA6uJIGFoJuOo3A2DJ0B+gM
+        4BgoNkFV5ImfdBO5WEMZHOz9SI16utDLNfNnCrt8UfRPJ/Cgmp31ogk+8Wfo67RvxcRYvNrObA+V
+        QTjc3MDBxdjoR1Uu9CvHfnsckuwDwgn7lzgKG4hGYzV5TCepF8y5T7CFHRtn+Ds64rbgAYWdYpIi
+        P2p0iSeJASBmwIW39FmpSIEAJa/GPGFVpe0rGeG4Afart1CcICJRqtLWoYYnVcO21pD8+QPVQqxW
+        BA1GYxT7RxFta+C7+D7EIa/EAzX2HkD4dMpnTWe0nzMh3cyEoJyamhB1bmo8Iah2bk5ISJMrJ8R0
+        5TNGhwkNTJ2QLk8IbDWuKUXntFOemTEhfT0h/5LsOn+Fz2DZWbPovNa1x549sfiydE0PydUxfaUh
+        GIjsINSVw2yggjYOgqZznrBOsBCxoDJNQjJETgtLj4IJfISW/sqzIyfqx2qcOavBs7tqNWTAPSYM
+        PIb0TV70IzD0L0m3C6kZWZo9PLyCLPV6h334LB2v50xQr7xPREfc/z0cMPA9xY/DUGrA0Qk+A5Fx
+        CYbATiukSyEQzBYT3kPpFeTDk2AA8eLYWwTAHGoBvf1oBj1htuPUIeoeZyejdwvGu3V4GA+A4C/j
+        mlJjGTHTBv4g+X4fYn4AJU7wt4y+wx6xWgBHuUxVxNkONGEweO9oozdZs7T7k7/ASKMa1KaFzxW4
+        tV8DeqLywVH1CapNxM5VLoAPjzeEdIAzeQrT/HjVAhKvbwv7S4MwrhAck3nStiwavXjjFIhH40Fe
+        45xkxKiAe4C4r+HEYJ1aHjwYI1MikV/g7Zl8I7mYpLBs8R0zwyiN/5Q2Lk9M4U2ybyihiM5PoR3R
+        pG++5ITjU+AVZdh0rgn5wJ9zE+TgpjMmzhxvDFczsMURgQLFl9GC9PSYnXHeJBVgHSEj1XNwBhNQ
+        zT3JmGhsnsENAvVuGKIUTyA1QACAalDwn8YueO03e6kfjh3sSTcldjNmvsM/2UWla97xrYN/+SeL
+        yQAhiCcepQ7/JkeKIaQiz/iW3i8oq/BIEPB8SjBc8BODSu3iBUnRYehqm2FsLJhYw6TwMWjyCOZ4
+        tNqlGBtKLxvjFk1FEmnIDHzOwSbNqKimHCzYKx0HD788J8zzuFFvZExxWKkye7SIl1DAAyoe1X6j
+        I6rmGWzGd6qGy9NdYmqhSD+MhrHEQAyfxgDe18SQl1TSYhBRvUrzCSr3Ittlp550+MdznTQvxxbP
+        CevJszoi5YdwgPLl7Ud0lzJdDsgSImQn9sv8gNCxYI8AID1xpqN2Jn7l/s1H9Cd3ZIJiZL0SGGZT
+        hqvYl+LLMTCa4BHvnzm1U84NzM44mpmL4CcmhgUWUqukQRr+OJKng38MuSclWx7JoxzQovOBtkGA
+        ULBg4fEyRo19KslH/p3H0CCVn/eHsCYeAUhdvzs/yUOhxHrhysuP6TB5e/4uu63hYwZHeelemzJt
+        HoPW0O4iCJAc/PYA6U/S+H6DW2CaRQ7RIOobI56y0PJIDPOLDCHyzsiqgZAM0xG/jxlVT3PZP1k5
+        Bfkv05Y0/ClPsaTRzBxLGluoaA8M3EyySuaPW8BQrOZbwAMb5yA+gIPs3KJxrGBkgXK9UgxnCeeQ
+        7YpTKrVB9jz8XnqAc/N2qK+MGmwk5gKiFgpt3zjEIaBgD4co+IlMA3jlHgMsSpnLpngLStKUQY8P
+        SPYJ6OAiQy2BGNjFEahromplfHGMYVYihL/Dvjt6DFIu1eu8PsnNGaBCCqaAfKYGhSYTOGXJatmI
+        na9PsZDQzBwLKY5J57nIjWnN024fUvdQc00tnWexApDHl8h1yFGJRZcPFXXDu4z4PPjFO+QSGoN4
+        gDYTOGy7Y48sCuXLXREz5yO7qAGVBqbmwaEwEEfBuEcOccQ98U3TC8jtMbDVzhuJLElO1cw3HGbA
+        duLd2pyNr8Lbj4HlDgcl3KFErXV+fHlped3RSMaMZxNwDlA8jZfYlo1Yw/yAuN6XMXbAjUPtdn4E
+        AZ3oNuJgwvz9JwRjIOJdjTDRtx+Litj4ZJyoMMZUopltRyUAAiJ93hRH9ReeoSxYEQ5xQennxj12
+        OPJJv7GUnBek0L1xcCJUO3rErDXoXfgOI2OyprDVPI7j8okTU1b1vpnHAWclomPQlJjJNOEb9Egt
+        us9qgtO0IhycOKUblbT2gBtDmbZoZg5mzsIndmpozYHqgmkgpvguHmfOo0DoXPydIk1Q1kjpsAeL
+        TjY6yR3Wgrw9DQMdTxdatGhR0qHE3x7DuADbIeriNQwifEDEpMFQ1WEez84JOVxoxkIpVtSb0cUf
+        HgtQSKXDb20PQpX0RZViQ5vmh49iZ4CvQXXDP+gmsVXdQaAxpF3vwwXEXxpvmt1zGTikCKpykwsr
+        bwAvjnNT9TbKNjzgypW8zVGvabm1VH/T7iStriXneOaL4DldGWhmjhV+at8hiQxedxTigXr548we
+        Oo9b+i1m624D7IHSzCV//Flpj5Yzo5ixlM0QzcBuPaKvRG7BxY3th4iVniJrEo4fHPg5/zrBOLEZ
+        njlYCZZeyUkmAWVj+Iz6x3AQIAOFBrlZdbjDApT3+gHMz0l5aGYOyksfgPIDPWav56Q8Pk9Ksc5R
+        f/QALrJUiF4yI5pBhXkqBHWvUhoUECFvoJ4p7XOg4JNwtJYHZ0Bc7nJ+2hzqY3UkSr4XE1nVRrKB
+        GdoVovtwQrrkRy/rnbJTgUiCK+ZgUZhMNiAOwdacgAc/jeNuT218IZ0KzcxB9zH/iCWFyj9Umu8P
+        066251wHiJWOe7M8efnBEjQvB4Ly7QtZybo/7PLAFtg+DuJZlCuj63fYGMo7IaCa0lk+8xO77h6B
+        GzreZKHlho5P8drinVFKIe3OeUSHtHeEXl2807v+whEBDDAmUwrJK75i9G0u45lOGdLXbx0c3Mc7
+        nacPnNcz+SnVk/qsy7jPmb34Hfduxij3E+ce8jrVmUE0sBMqOsDei484OpH1oTy2NbNvlfE2Y2hJ
+        75TdolMWjczGZFZTPVGqLvb8q6hyOAdTjGdNOoD5QAKZvgoDFOTDxlOCUqPYCdWOj3mUjjRPCcLL
+        ne4ycC/VjvnC9erZaavN9ANSePYHReu1/qWj9AqqeXTgPO+ljEzroWlt9wH7jQpQQNmbQTOX6hy4
+        4hrOdjW2C6cIJCQKubuLCQM+Bnlo3IyGk4PliusLND10O3Qa3YyGz+QTorixQLMMMaoXzGqYIaZn
+        RHFzgaY9GLLY/D2zac4ZlE1vLdD0EBufKEUHZ5PyKcOzsKIfRUozH0hcfDWjI8ynjU2SN3Y8pdMW
+        C5zD/KAovp7RXpZA2p4/A1ZNcwaJbBuNK55vZO0oqp/CJhKL72W8w27acH6nta/3sVFJGvbHIRsJ
+        Sk9hXwOInQ7yxpyWSb7HS/IE3SaaVyooq8DxCtaWP+qgz9Y/5jTAqJ66PpIOaTnI6yURR4LNOsVp
+        elqizj0ygjaP45lzlZeeQ3CYA06POs8I6lPeEDZMUtqQpc/5U3bwbNRkLSETBym+yUDQgLTf5UE4
+        RvZ9aeDA7fRoQPQUnFIr3wkNSvnc0JmIjwYmhw5MuUL4UQucP85C00PaVqJjSTWkjm0zAyGXA7mb
+        jEOdFnCd1HF6Wxvllqao6vvyfozmuSd6eot/RjLV9Pa8Nuq7ajtV85PQuvH8u4GD1DgcR6FYyQyW
+        e+oiox7xj/xuIA5SvUwHNbZ7i+eHzcOEaZs8m1S82RxblTBKtoCf1S5lrintUEiXw0kOKlN+K9P9
+        bNRtyl1nsBQ5LErc11Lp4uPQHtojVWwCp62ps3DO7BFlyL4vo/wuHdcB7qPSLs1dn9i1RQVQUdzI
+        0gSSLl8ls1JT6ABznBypqdti5z5SClo2HadDWainuVmoeQOclYVlss9YzVUJmjE7i9NOkWapss5S
+        J6Hl00tW3PMm8nQ2+jQSWhCqw1SG/RTyzYLT9qGNzQjdLAqDbE7LtflQ0hm3bzgOMZWTLAjFERok
+        2jPCEDNZzyLZUwuCMi3V6kGGjiAAbblo30/lVItCohtc2JpONmo/GSwTO/DnoxQUNZkelFgQH8do
+        a2FUJFH3J1q0nAlAOqHOKzFdpzFSZqtIyCizqBaKRY6dmYHYBVH01vHhA40oO1IdZjhD9ppGLzLu
+        sUPwqajlLbcWIyO1lCGOJxzUqHlJESBT+GkBlIljLYiPd7LhfEiynFVC4baxoyV2/Fvn7y5rM4NJ
+        j4KItmAZvcwJnzzZ86kmSR0UOl/fCLm1lAxFRYxZWSsL4kOGzBGtUFFzfJoPolQU+onW9omZHDGR
+        u5gi4yzxYC8nZ3A92RqamhI2E4yUEUj7GJ5yrtKqPHY4zQQFZYTCng9nGhVEfSqi/Te3g42zdSgg
+        XKGLLHQqQshcbmJrEymVYDeDdttzIrL9yrT9O440nUIHpk2DHs76oXqUiA1gm2O+ZbQgVVNkI4Qt
+        jt2TRhQRX3y5zQFbNWIqN5VlHA+OPCpUTeB9A/Ps3jqtJy88BviH3CKxDp2Oz8HLD5QoGyLQUXPC
+        IBw12ZSCBMLv8w+nxpp4Rx6gwqmkVzAiGhmQ48l5UOtLQmB3Ri7IHKFwXXxlas8pMwtW5xy0kZQS
+        ZtdRCjG0EKSdHNvbj6GXHONKmd8xzlLdZvlkJj7eGbaGnVa//ZRsKpNLMB9ceh6fCCdxFCgOJl3J
+        0PB80FA9nal0uyAvorIsge8neaEz50f7IZ4IDzJqlzC7mX2Dtjj3/6lGDtnA7fFO91hv1zMy30zo
+        tMAnwselPBBqzr75yMUnwwa3xu7sZMPg3ICA2bPEfUJodJP5MIBfkYGCk9ipJD+sJD7k5fcQ3jiI
+        XHWZD1mWpT0Uu15wvarQ9nx9s3Mq5CrVQ6fj2k9vQjW4cXFGrc8HE2WDsPKTOjH4qQgnrgGhEypS
+        Kta8EIK9NulkjqHv3ZfhaHyi5R23yXCkmF2e3ftUvap8rfkGn+c7c7Dlqndf6ji3zsAfUXiBjHQP
+        tUECOIRp8T2hyQc3u9HyfEDf4qgWGGfIOnkqOvqgW5wPgDsnYrp+qu4/qvbm7B1FieUcPRHJfESD
+        SF6mWWcIOB5NsQ1214eGv54cMBy+gEqpVVKVhC2LXKD6xmSJC/WkeKY+PHv+zIyC8hkwcXjTvKMK
+        zMcHFcQPsSZOERQqm0E1kGUpRZwckH5kpC244RjF58kYAfxjLsrY2UkUZG4uKdJxRJVuYNSg5MxO
+        bbhGAz7HxkE+YHV9nQ9hfR0Plx/W1iY1RD8TdWA0CuRt+YyGnwylYy6lnwWfQJp1aAq9CUCpCr88
+        yNR8AVNR7yD+i3MmaQSZM5JmAoSD3bGrWMOU4lwZeYczExBGWvJa4WiXlCr5CTxfftDqlfymvJDy
+        C+U2yk+XamuZ/PYfaW+pkvwd351D5O/juE2oecSyZGN+V/5F2or8wE4d1+c01vT8z+odgbR5en/f
+        qNFjtIZEbnMZ5Fmco8mVgq/lMU+o4lKj0soZqBfHcQqG9JqYFYeWAHFlErdFFQvuJa/fp2JQ2Aot
+        r6Uan0UdcoBc0wJbS1RTl4F7a7eZ08wxA7kok+fP6waNI88WQHvHDeHdwZEYgYLrKL7A40shba7Z
+        pL1rrZE7RJV/11aNHl+c1Kg5tdzkH+YdeIpPz8DSJHYAlqhyB62jkw/7spKPdXhx3qydnNevZMzY
+        Org4+iTLCXGeZQdnMuFwqLY/HLmIkKO03xiVG0JdYnyVjgNLis2D37gdyhvo4mFsm9OHR8m25YkR
+        6iwDiiYfAL4Niw7kRSzgS2i18B2FfrB9cogKxDhnggrtyFM1nqvjNeZ5G6VKZVWpTBPS84UlRGfv
+        BKie37R7IvTc0ciJ2GaL7kdOyabDRwhgEfdJ13FQA/avW19s+F3lkRj7zy1r78Xnw6Nas/ZZzSUd
+        9YGlLM+GRMU0r+v2RFX8xs6+d2BaA2enoPIPCuLbrq6oQO8p9FSFPnyjnD7xQx/FsbKrOpMvlAk6
+        9DEBX+YxHCFBT+nItwSxrPlOMq4Qm12GoJvywKdDWPjUENVhDFhyRolxiEmBEFegk0zKqDeJmOBh
+        HxUhixJKAA10/fIL6k4lU0qyBDJETJkSEnmoXSWfYiET+f4gckd0Q9PDtLkhiv9DUZ/FIoor4rd4
+        vf2hWPiMoonVZdXe8i84ikx9Lir0fsPfGFSCgQDFM7p7A6qRP6JN/wZURBriUl7mHPfnWVAYFpp1
+        ehNPosZWFaddDUJH0cQfissMo2r8l+WVsvpYTAYSodBZzwl2xDJysbDullfjMaK6kdwnhpuoE7ks
+        KQ1gBQ7dQtxD9KlvmZ+B5MjQ4a+gUVSMom/jiBv7tlKO7xr4dEyEotm7Pmr3c4vUtGpKoLwfJw/d
+        IQ2oL/pgCLZQw1gVfTjqY3jRBEQoDhkAt3G+tp2RPBGtjZO0KPvI9xycKxdDDU40RiHB+O0cbIGD
+        F5dfLoufQAbIQgpXynYUBcVlt7O8kuBymYBYjpeUoJP2xB8UiJgS9a5eS6ApdS+ejWUc9nBHLcTA
+        YCjgaBhpdwAGw4jBhglgFanyOA1uKGS+DMUCVGPmqx03QNl4PIIxD+7FHVICT8B/6TwJDAMhBC78
+        ibJlMJ48OUVE6+iUjg0jDFHCuh5B3DviFqj3xmXhwNJxukwYmr3SO5gkKHsI6KIUbAsRDDqfjq4j
+        lhE/Gg+f4snFZdUNiBProqgoBWA5gUEqJqUQqEQcl4rk6fSbBLma1jiFb84W1KKhhvVPDKQCrzgx
+        y7S6eUy6R1C70V+WuFHHmNeAwGOEfzmB8qA2eWqfOnxK4z3GF6YFZ7CsVyoVMcQpi24Icxjuiuo6
+        PuCYIzoNZZlmBqd3phePMYlxYw/RJqiuCXUjPZYs9tFp8UU8Bdm7hMKH0UdPfYvB+kb2SqWiFhGh
+        Npd5qslgrv4Q936W8Mviym9E3Fr2gH/ZnfvnOOFOEP6KL15g7ZfhWmnf3IMM4U8GFoorGBe9NbRv
+        QNF0smRBPVOIeZLzFaZmKFuS6162ApOUF35OqxASKNGDdlEFEHWz9YE5Qjfyh+IdDF3/bqUMqYfC
+        eDFJqUHIq0KuXB4CYZKmVb6nu063gquQSjO6lZhIoN9Lmlv5Le6G5KExpnYYFn8DvcLCg8MFUqLr
+        fnU6yziHxx/tiIqgOSQk08+3+JMDCQVJqm/ktAmeIJtcXl1G0hYmhpijfuGbRhWvQLrKV7izWNxK
+        ma/NUhK8IBrUVcVhVvvP/w8qylglRucAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html
+      Date:
+      - Sat, 12 Nov 2022 04:59:53 GMT
+      Permissions-Policy:
+      - interest-cohort=()
+      Referrer-Policy:
+      - no-referrer-when-downgrade
+      Server:
+      - nginx/1.19.5
+      Transfer-Encoding:
+      - chunked
+      X-NA:
+      - '0'
+      X-NID:
+      - '-'
+      X-Page-Cache:
+      - MISS
+      X-RL:
+      - '0'
+      X-location:
+      - All
+      cache-control:
+      - max-age=1800
+      content-security-policy:
+      - 'default-src ''self'' ''unsafe-eval'' ''unsafe-inline'' data: blob: archive.org
+        web.archive.org analytics.archive.org pragma.archivelab.org'
+      link:
+      - <https://www.fws.gov/>; rel="original", <https://web.archive.org/web/timemap/link/https://www.fws.gov/>;
+        rel="timemap"; type="application/link-format", <https://web.archive.org/web/https://www.fws.gov/>;
+        rel="timegate", <https://web.archive.org/web/19970118072440/http://www.fws.gov:80/>;
+        rel="first memento"; datetime="Sat, 18 Jan 1997 07:24:40 GMT", <https://web.archive.org/web/20171124143727/http://www.fws.gov/>;
+        rel="prev memento"; datetime="Fri, 24 Nov 2017 14:37:27 GMT", <https://web.archive.org/web/20171124143728/https://www.fws.gov/>;
+        rel="memento"; datetime="Fri, 24 Nov 2017 14:37:28 GMT", <https://web.archive.org/web/20171124232038/https://www.fws.gov/>;
+        rel="next memento"; datetime="Fri, 24 Nov 2017 23:20:38 GMT", <https://web.archive.org/web/20221111175333/https://www.fws.gov/>;
+        rel="last memento"; datetime="Fri, 11 Nov 2022 17:53:33 GMT"
+      memento-datetime:
+      - Fri, 24 Nov 2017 14:37:28 GMT
+      server-timing:
+      - captures_list;dur=4171.233987, exclusion.robots;dur=0.344926, exclusion.robots.policy;dur=0.328599,
+        cdx.remote;dur=0.132487, esindex;dur=0.013337, LoadShardBlock;dur=224.268813,
+        PetaboxLoader3.datanode;dur=226.779999, CDXLines.iter;dur=41.969039, load_resource;dur=104.245962,
+        PetaboxLoader3.resolve;dur=63.727458
+      x-app-server:
+      - wwwb-app212
+      x-archive-orig-accept-ranges:
+      - bytes
+      x-archive-orig-date:
+      - Fri, 24 Nov 2017 14:37:27 GMT
+      x-archive-orig-etag:
+      - '"874c4f6aa563d31:0"'
+      x-archive-orig-last-modified:
+      - Wed, 22 Nov 2017 15:20:22 GMT
+      x-archive-orig-strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-archive-orig-transfer-encoding:
+      - chunked
+      x-archive-src:
+      - archiveteam_archivebot_go_20171125060002/nostalgia.esmartkid.com-inf-20171124-135423-93c54-00000.warc.gz
+      x-tr:
+      - '4327'
+      x-ts:
+      - '200'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/wayback/tests/test_client.py
+++ b/wayback/tests/test_client.py
@@ -251,6 +251,46 @@ def test_get_memento():
             'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
             'Transfer-Encoding': 'chunked'
         }
+        assert memento.links == {
+            'first memento': {
+                'datetime': 'Wed, 23 Mar 2005 15:53:00 GMT',
+                'rel': 'first memento',
+                'url': 'https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds'
+            },
+            'last memento': {
+                'datetime': 'Thu, 06 Oct 2022 03:10:05 GMT',
+                'rel': 'last memento',
+                'url': 'https://web.archive.org/web/20221006031005/https://fws.gov/birds'
+            },
+            'prev memento': {
+                'datetime': 'Fri, 29 Sep 2017 00:27:12 GMT',
+                'rel': 'prev memento',
+                'url': 'https://web.archive.org/web/20170929002712/https://www.fws.gov/birds/'
+            },
+            'next memento': {
+                'datetime': 'Thu, 28 Dec 2017 22:21:43 GMT',
+                'rel': 'next memento',
+                'url': 'https://web.archive.org/web/20171228222143/https://www.fws.gov/birds/'
+            },
+            'memento': {
+                'datetime': 'Fri, 24 Nov 2017 15:13:15 GMT',
+                'rel': 'memento',
+                'url': 'https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/'
+            },
+            'original': {
+                'rel': 'original',
+                'url': 'https://www.fws.gov/birds/'
+            },
+            'timegate': {
+                'rel': 'timegate',
+                'url': 'https://web.archive.org/web/https://www.fws.gov/birds/'
+            },
+            'timemap': {
+                'rel': 'timemap',
+                'type': 'application/link-format',
+                'url': 'https://web.archive.org/web/timemap/link/https://www.fws.gov/birds/'
+            },
+        }
 
 
 @ia_vcr.use_cassette()

--- a/wayback/tests/test_client.py
+++ b/wayback/tests/test_client.py
@@ -540,6 +540,15 @@ def test_get_memento_follow_redirects_does_not_follow_historical_redirects():
         assert len(memento.debug_history) == 1
 
 
+@ia_vcr.use_cassette()
+def test_get_memento_returns_memento_with_accurate_url():
+    with WaybackClient() as client:
+        # This memento is actually captured from 'https://www.', not 'http://'.
+        memento = client.get_memento('http://fws.gov/',
+                                     timestamp='20171124143728')
+        assert memento.url == 'https://www.fws.gov/'
+
+
 def return_timeout(self, *args, **kwargs) -> requests.Response:
     """
     Patch requests.Session.send with this in order to return a response with


### PR DESCRIPTION
This fixes an issue where the `Memento.url` property could be slightly incorrect, since it was based on the URL you requested the memento from (e.g. `https://web.archive.org/web/20221010000000/<url>`), rather than the actual URL the memento was captured from. The URL the memento is requested from matches records via SURT key rather than the URL.

For example, requesting an archived copy of `http://fws.gov/` might return a capture of `https://www.fws.gov/` instead. The returned Memento object’s `url` property used to be `http://fws.gov/` in this case, but this changes it to be `https://www.fws.gov/`.

Fixes #99.