### PR TITLE
Ensure memento's links match memento's mode

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -22,22 +22,22 @@ Features
           'rel': 'original'
       },
       'first memento': {
-          'url': 'https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds',
+          'url': 'https://web.archive.org/web/20050323155300id_/http://www.fws.gov:80/birds',
           'rel': 'first memento',
           'datetime': 'Wed, 23 Mar 2005 15:53:00 GMT'
       },
       'prev memento': {
-          'url': 'https://web.archive.org/web/20210125125216/https://www.fws.gov/birds/',
+          'url': 'https://web.archive.org/web/20210125125216id_/https://www.fws.gov/birds/',
           'rel': 'prev memento',
           'datetime': 'Mon, 25 Jan 2021 12:52:16 GMT'
       },
       'next memento': {
-          'url': 'https://web.archive.org/web/20210321180831/https://www.fws.gov/birds',
+          'url': 'https://web.archive.org/web/20210321180831id_/https://www.fws.gov/birds',
           'rel': 'next memento',
           'datetime': 'Sun, 21 Mar 2021 18:08:31 GMT'
       },
       'last memento': {
-          'url': 'https://web.archive.org/web/20221006031005/https://fws.gov/birds',
+          'url': 'https://web.archive.org/web/20221006031005id_/https://fws.gov/birds',
           'rel': 'last memento',
           'datetime': 'Thu, 06 Oct 2022 03:10:05 GMT'
       }

--- a/wayback/_models.py
+++ b/wayback/_models.py
@@ -231,7 +231,7 @@ class Memento:
           view_memento = client.get_memento('https://fws.gov/birds', '20210318004901', mode=Mode.view)
           view_memento.links['next memento']['url'] == 'https://web.archive.org/web/20210321180831/https://fws.gov/birds'
           # Nothing after the timestamp for "view" mode -----------------------------------------^
-    """
+    """  # noqa: E501
 
     def __init__(self, *, url, timestamp, mode, memento_url, status_code,
                  headers, encoding, raw, raw_headers, links, history,

--- a/wayback/_models.py
+++ b/wayback/_models.py
@@ -186,9 +186,11 @@ class Memento:
         Related links to this Memento (e.g. the previous and/or next Memento in
         time). The keys are the relationship (e.g. ``'prev memento'``) as a
         string and the values are dicts where the keys and values are strings.
-        One key will be ``'url'``, indicating the URL of the related link, and
-        the rest will be any other attributes specified for the link
-        (e.g. ``'rel'``, ``'type'``, etc.).
+
+        In each entry, the ``'url'`` key is the URL of the related link, the
+        ``'rel'`` key is the relationship (the same as the key in the top-level
+        dict), and the rest of the keys will be any other attributes that are
+        relevant for that link (e.g. ``'datetime'`` or ``'type'``).
 
         For example::
 
@@ -218,6 +220,17 @@ class Memento:
                   'datetime': 'Thu, 06 Oct 2022 03:10:05 GMT'
               }
           }
+
+        Links to other mementos use the same mode as the memento object this
+        ``links`` attribute belongs to. For example::
+
+          raw_memento = client.get_memento('https://fws.gov/birds', '20210318004901')
+          raw_memento.links['next memento']['url'] == 'https://web.archive.org/web/20210321180831id_/https://fws.gov/birds'
+          # The "id_" after the timestamp means "original" mode ---------------------------------^^^
+
+          view_memento = client.get_memento('https://fws.gov/birds', '20210318004901', mode=Mode.view)
+          view_memento.links['next memento']['url'] == 'https://web.archive.org/web/20210321180831/https://fws.gov/birds'
+          # Nothing after the timestamp for "view" mode -----------------------------------------^
     """
 
     def __init__(self, *, url, timestamp, mode, memento_url, status_code,

--- a/wayback/_utils.py
+++ b/wayback/_utils.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 URL_DATE_FORMAT = '%Y%m%d%H%M%S'
 MEMENTO_URL_PATTERN = re.compile(
     r'^http(?:s)?://web.archive.org/web/(\d+)(\w\w_)?/(.+)$')
+MEMENTO_URL_TEMPLATE = 'https://web.archive.org/web/{timestamp}{mode}/{url}'
 
 
 def format_timestamp(value):
@@ -159,6 +160,43 @@ def memento_url_data(memento_url):
     mode = match.group(2) or ''
 
     return url, date, mode
+
+
+def format_memento_url(url, timestamp, mode=''):
+    """
+    Get the URL for a memento of a given URL, timestamp, and mode.
+
+    Parameters
+    ----------
+    url : str
+    timestamp : str or datetime.datetime or datetime.date
+    mode : str
+
+    Returns
+    -------
+    str
+    """
+    return MEMENTO_URL_TEMPLATE.format(url=url,
+                                       timestamp=format_timestamp(timestamp),
+                                       mode=mode)
+
+
+def set_memento_url_mode(url, mode):
+    """
+    Return a memento URL with the "mode" component set to the given mode. If
+    the URL is not a memento URL, raises ``ValueError``.
+
+    Parameters
+    ----------
+    url : str
+    mode : str
+
+    Returns
+    -------
+    str
+    """
+    captured_url, timestamp, _ = memento_url_data(url)
+    return format_memento_url(captured_url, timestamp, mode)
 
 
 _last_call_by_group = defaultdict(int)

--- a/wayback/tests/test_client.py
+++ b/wayback/tests/test_client.py
@@ -255,27 +255,27 @@ def test_get_memento():
             'first memento': {
                 'datetime': 'Wed, 23 Mar 2005 15:53:00 GMT',
                 'rel': 'first memento',
-                'url': 'https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds'
+                'url': 'https://web.archive.org/web/20050323155300id_/http://www.fws.gov:80/birds'
             },
             'last memento': {
                 'datetime': 'Thu, 06 Oct 2022 03:10:05 GMT',
                 'rel': 'last memento',
-                'url': 'https://web.archive.org/web/20221006031005/https://fws.gov/birds'
+                'url': 'https://web.archive.org/web/20221006031005id_/https://fws.gov/birds'
             },
             'prev memento': {
                 'datetime': 'Fri, 29 Sep 2017 00:27:12 GMT',
                 'rel': 'prev memento',
-                'url': 'https://web.archive.org/web/20170929002712/https://www.fws.gov/birds/'
+                'url': 'https://web.archive.org/web/20170929002712id_/https://www.fws.gov/birds/'
             },
             'next memento': {
                 'datetime': 'Thu, 28 Dec 2017 22:21:43 GMT',
                 'rel': 'next memento',
-                'url': 'https://web.archive.org/web/20171228222143/https://www.fws.gov/birds/'
+                'url': 'https://web.archive.org/web/20171228222143id_/https://www.fws.gov/birds/'
             },
             'memento': {
                 'datetime': 'Fri, 24 Nov 2017 15:13:15 GMT',
                 'rel': 'memento',
-                'url': 'https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/'
+                'url': 'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/'
             },
             'original': {
                 'rel': 'original',
@@ -408,12 +408,22 @@ def test_get_memento_with_mode():
                                      timestamp=datetime(2017, 11, 24, 15, 13, 15),
                                      mode=Mode.view)
         assert '' == memento.mode
-        assert 'https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/' == memento.memento_url
+        assert ('https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/'
+                == memento.memento_url)
+        assert ('https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/'
+                == memento.links['memento']['url'])
+        assert ('https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds'
+                == memento.links['first memento']['url'])
 
         memento = client.get_memento('https://www.fws.gov/birds/',
                                      timestamp=datetime(2017, 11, 24, 15, 13, 15))
         assert 'id_' == memento.mode
-        assert 'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/' == memento.memento_url
+        assert ('https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/'
+                == memento.memento_url)
+        assert ('https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/'
+                == memento.links['memento']['url'])
+        assert ('https://web.archive.org/web/20050323155300id_/http://www.fws.gov:80/birds'
+                == memento.links['first memento']['url'])
 
 
 @ia_vcr.use_cassette()


### PR DESCRIPTION
The `links` attribute on a Memento object links to other related resources, such as the first/previous/next/last memento of the current memento's URL. These are super useful for iterating and navigating through mementos, BUT the archive.org servers always return these as links to the memento in "view" mode. Users of this library rarely use "view" mode, and if you are iterating through links in a different mode, simply following one of the links can lead to subtle mistakes! To mitigate this, we now change all the links that reference mementos to use the same mode as the `Memento` object they are attached to.

Fixes #111.