### PR TITLE
Fix docstring for WaybackClient

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,7 @@ Thanks to the following people for their contributions and help on this package!
 - `Will Sackfield <https://github.com/8W9aG>`_ (Code, Tests)
 - `Ed Summers <https://github.com/edsu>`_ (Code, Tests)
 - `Lion Szlagowski <https://github.com/LionSzl>`_ (Code, Tests)
+- `David Gilman <https://pro-football-history.com>`_ (Complaints)
 
 
 License & Copyright

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -456,7 +456,7 @@ class WaybackClient(_utils.DepthCountedContext):
 
     Parameters
     ----------
-    session : :class:`requests.Session`, optional
+    session : :class:`WaybackSession`, optional
     """
     def __init__(self, session=None):
         self.session = session or WaybackSession()


### PR DESCRIPTION
The client refers to some of the class members from WaybackSession (e.g. `search_calls_per_second`) so this needs to be an instance of WaybackSession