### PR TITLE
Prevent installation with urllib3 v2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-urllib3
+urllib3 >=1.20, <2


### PR DESCRIPTION
Right now, this package is not compatible with urllib3 v2, so we need to set version constraints so package managers don’t try to install an incompatible version.

Partially covers #116.