### PR TITLE
Upgrade Flake8 to v6.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ commands:
     parameters:
       python-version:
         type: string
+      install-dev:
+        description: Install dev dependencies (not just test dependencies)
+        type: boolean
+        default: false
       install-docs:
         description: Install docs dependencies
         type: boolean
@@ -26,7 +30,17 @@ commands:
             # Ensure pip is up-to-date
             pip install --upgrade pip
             pip install .
-            pip install -r requirements-dev.txt  # Extra requirements for tests.
+            pip install -r requirements-test.txt  # Extra requirements for tests.
+
+      # Dev dependencies are only compatible on Python 3.8+, so only install
+      # them on demand.
+      - when:
+          condition: << parameters.install-dev >>
+          steps:
+            - run:
+                command: |
+                  . ~/venv/bin/activate
+                  pip install -r requirements-dev.txt
 
       # Docs dependencies are only compatible on Python 3.10+, so only install
       # them on demand.
@@ -76,6 +90,7 @@ jobs:
       - checkout
       - setup_pip:
           python-version: "3.11"
+          install-dev: true
       - run:
           name: Code linting
           command: |
@@ -90,6 +105,7 @@ jobs:
       - checkout
       - setup_pip:
           python-version: "3.11"
+          install-dev: true
       - run:
           name: Build Distribution
           command: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ wheel
 check-wheel-contents ~=0.1.0
 codecov
 coverage
-flake8 ~=5.0.4
+flake8 ~=6.1.0
 requests-mock
 pytest
 vcrpy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,8 @@
 # These are required for developing the package (running the tests, packaging
-# etc.) but not necessarily required for _using_ it.
+# etc.) but not necessarily required for _using_ it. Some dev tooling requires
+# newer Python versions than the package itself (>=3.8)
 wheel
 check-wheel-contents ~=0.1.0
-codecov
-coverage
 flake8 ~=6.1.0
-requests-mock
-pytest
-vcrpy
 twine
+-r requirements-test.txt

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,9 @@
+# These are required for testing the package but not necessarily required for
+# _using_ it or for other build-time tasks (packaging, linting, etc.).
+# Some dev tooling requires newer versions of Python (3.8+) than we want to
+# require for the whole package.
+codecov
+coverage
+requests-mock
+pytest
+vcrpy

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         'Issues': 'https://github.com/edgi-govdata-archiving/wayback/issues',
     },
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 3 - Alpha',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
     ],


### PR DESCRIPTION
Earlier versions of flake8 do not support Python 3.12. Part of #123.