### PR TITLE
Support Python 3.12 Prereleases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,13 +138,55 @@ jobs:
             . ~/venv/bin/activate
             make -C docs html
 
+  test-python-prerelease:
+    working_directory: ~/wayback
+    docker:
+      - image: mr0grog/circle-python-pre:3.12.0rc3
+    steps:
+      - checkout
+      - setup_pip:
+          python-version: 3-12-pre
+          install-dev: true
+
+      - run:
+          name: Tests
+          command: |
+            . ~/venv/bin/activate
+            coverage run -m pytest -vv
+      - run:
+          name: Coverage
+          command: |
+            . ~/venv/bin/activate
+            coverage report -m
+
+      # Lint
+      - run:
+          name: Code linting
+          command: |
+            . ~/venv/bin/activate
+            flake8 .
+
+      # Build
+      - run:
+          name: Build Distribution
+          command: |
+            . ~/venv/bin/activate
+            python setup.py sdist bdist_wheel
+      - run:
+          name: Check Distribution
+          command: |
+            . ~/venv/bin/activate
+            twine check dist/*
+            check-wheel-contents --toplevel wayback dist
+
 workflows:
-  build:
+  ci:
     jobs:
       - test:
           matrix:
             parameters:
               python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+      - test-python-prerelease
       - lint
       - build
       - docs

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,5 +5,6 @@
 codecov
 coverage
 requests-mock
+setuptools ~=68.2
 pytest
 vcrpy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,6 @@
 codecov
 coverage
 requests-mock
-setuptools ~=68.2
+setuptools
 pytest
 vcrpy


### PR DESCRIPTION
This currently adds tests for Python 3.12.0 pre-releases (at the time of writing: 3.12.0rc3). It looks like there are some remaining issues to iron out in order to totally solve #123.