### PR TITLE
Add Dependabot for dev dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,7 @@ commands:
             . ~/venv/bin/activate
             # Ensure pip is up-to-date
             pip install --upgrade pip
-            pip install .
-            pip install -r requirements-test.txt  # Extra requirements for tests.
+            pip install .[test]
             pip install 'urllib3 ~=<< parameters.urllib3-version >>'
 
       # Dev dependencies are only compatible on Python 3.8+, so only install
@@ -44,7 +43,7 @@ commands:
             - run:
                 command: |
                   . ~/venv/bin/activate
-                  pip install -r requirements-dev.txt
+                  pip install .[dev]
 
       # Docs dependencies are only compatible on Python 3.10+, so only install
       # them on demand.
@@ -54,7 +53,7 @@ commands:
             - run:
                 command: |
                   . ~/venv/bin/activate
-                  pip install -r requirements-docs.txt
+                  pip install .[docs]
 
       - save_cache:
           key: cache_v6-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-docs.txt" }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: monthly
+  allow:
+    - dependency-type: "development"
+  open-pull-requests-limit: 10

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,4 +22,6 @@ python:
   install:
     - method: pip
       path: "."
-    - requirements: "requirements-docs.txt"
+      extra_requirements:
+        - dev
+        - docs

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as readme_file:
 # https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
 REQUIREMENT_DELIMITER = re.compile(r';|--')
 
+
 def read_requirements(filename):
     """
     Read a pip requirements file into a list of standard package requirements.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from os import path
+import re
 from setuptools import setup, find_packages
 import sys
 import versioneer


### PR DESCRIPTION
My understanding (we'll see, might be wrong!) is that dependabot will include `extras_require` entries as dev dependencies, so I've made deps installable that way (really that should have been done long ago): `pip install wayback[dev,test,docs]`.