### PR TITLE
Update docs dependencies

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,8 +2,8 @@
 # there are a variety of compatibility issues with our other dev dependencies
 # on Python versions < 3.10 (which we support), so you have to install them in
 # a separate environment from the other dev dependencies.
-sphinx ~=5.2.2
-ipython ~=7.16.2
-numpydoc ~=1.4.0
-sphinx-copybutton ~=0.5.0
-sphinx_rtd_theme ~=1.0.0
+sphinx ~=7.2.6
+ipython ~=8.16.1
+numpydoc ~=1.6.0
+sphinx-copybutton ~=0.5.2
+sphinx_rtd_theme ~=1.3.0


### PR DESCRIPTION
Now that Sphinx 7 and the various Sphinx themes and plugins we use all work correctly together, we should update all the docs tools. This includes some security fixes, useful bugfixes, and some new features I want to use (`maximum_signature_line_length` in Sphinx looks useful).