### PR TITLE
Tell git to treat `.py` files as Python

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 wayback/_version.py export-subst
+*.py diff=python


### PR DESCRIPTION
It turns out git has some neat language specific features it can enable if we tell it that `.py` files are Python code, e.g. https://calebhearth.com/git-method-history.