### PR TITLE
A little more rate limit tweaking for v0.4.4

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -22,6 +22,7 @@ Fixes & Maintenance
 
 - Adjusted default rate limits to work better with current throttling in use at archive.org. (:issue:`140`)
 - Added more logging around requests are rate limiting. (:issue:`139`)
+- Fix calculation of the ``time`` attribute on :class:`wayback.exceptions.WaybackRetryError`. It turns out it was only accounting for the time spent waiting between retries and skipping the time waiting for the server to respond. (:issue:`142`)
 
 
 v0.4.3 (2023-09-26)

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -418,7 +418,7 @@ class WaybackSession(_utils.DisableAfterCloseSession, requests.Session):
                 if retries >= maximum:
                     raise WaybackRetryError(retries, total_time, error) from error
                 elif self.should_retry_error(error):
-                    logger.warn('Caught exception during request, will retry: %s', error)
+                    logger.info('Caught exception during request, will retry: %s', error)
                 else:
                     raise
 

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -404,7 +404,7 @@ class WaybackSession(_utils.DisableAfterCloseSession, requests.Session):
                 result = super().send(*args, **kwargs)
                 if retries >= maximum or not self.should_retry(result):
                     if result.status_code == 429:
-                        raise RateLimitError(result)
+                        raise RateLimitError(result, _utils.parse_retry_after(result.headers.get('Retry-After')))
                     return result
                 else:
                     # TODO: parse and use Retry-After header if present.

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -406,15 +406,15 @@ class WaybackSession(_utils.DisableAfterCloseSession, requests.Session):
             retry_delay = 0
             try:
                 logger.debug('sending HTTP request %s "%s", %s', args[0].method, args[0].url, kwargs)
-                result = super().send(*args, **kwargs)
-                retry_delay = self.get_retry_delay(retries, result)
+                response = super().send(*args, **kwargs)
+                retry_delay = self.get_retry_delay(retries, response)
 
-                if retries >= maximum or not self.should_retry(result):
-                    if result.status_code == 429:
-                        raise RateLimitError(result, retry_delay)
-                    return result
+                if retries >= maximum or not self.should_retry(response):
+                    if response.status_code == 429:
+                        raise RateLimitError(response, retry_delay)
+                    return response
                 else:
-                    logger.debug('Received error response (status: %s), will retry', result.status_code)
+                    logger.debug('Received error response (status: %s), will retry', response.status_code)
             except WaybackSession.handleable_errors as error:
                 response = getattr(error, 'response', None)
                 if response:

--- a/wayback/exceptions.py
+++ b/wayback/exceptions.py
@@ -90,15 +90,9 @@ class RateLimitError(WaybackException):
         ``None``.
     """
 
-    def __init__(self, response):
+    def __init__(self, response, retry_after):
         self.response = response
-
-        # The Wayback Machine does not generally include a `Retry-After` header
-        # at the time of this writing, but this code is included in case they
-        # add it in the future. The standard recommends it:
-        # https://tools.ietf.org/html/rfc6585#section-4
-        retry_header = response.headers.get('Retry-After')
-        self.retry_after = int(retry_header) if retry_header else None
+        self.retry_after = retry_after
 
         message = 'Wayback rate limit exceeded'
         if self.retry_after:


### PR DESCRIPTION
This adds a bunch of little tweaks related to the recent rate limit work. It should be more-or-less ready for release after this.

**The main thing** is adding a 60-second delay for 429 (rate limit) responses. Looking back at the docstring for the `RateLimitError` class, I think I might have originally *intended* to always raise instead of retry these, but git history shows it never actually worked that way. I want to get a patch release out with the new retry timings and logs, but patch release doesn’t seem like a good time change whether a response gets retried, so I’ve just made a longer delay here for now.

Then some other assorted bits and bobs:

- Downgrades the log level when we catch and retry exceptions (used to be WARN, now just INFO). The whole point of retry is to make this situations not special, so I don’t think it’s actually worth a warning.

- Actually handle all forms of `Retry-After` header, and move logic to `_utils`. We didn’t previously handle the date form of the header, just the integer form that indicated a number of seconds. Now we handle both. I also moved the logic out of the `exceptions` module since it was too much special logic (arguably this was already the case even before I improved the parsing).

- Fix the `total_time` calculation for `WaybackRetryError`. I’m not sure what I was thinking with the previous code, which was… not even sort-of correct.

- Add `read_and_close()` everywhere that we raise an exception. We did it in some spots, but had missed others.