### PR TITLE
Stop retrying after rate limit errors

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -8,7 +8,9 @@ In Development
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
-- N/A
+- Wayback will no longer automatically pause and retry when the server returns rate-limit errors. Instead, it will raise a :class:`wayback.exceptions.WaybackRetryError` exception (which includes information how long you should probably pause for in the ``time`` attribute). If you need to keep operating
+
+  The previous behavior helped solve some issues with the way rate limits were implemented on the client side that have since been fixed. It was also designed around users who had custom limits on Internet Archive servers, which is an unusual situation. The new approach is safer and can help prevent your IP address from getting blocked. If you need to retry after rate limit errors, make sure your code handles the exception and pauses all requests on all client instances for an appropriate amount of time.
 
 
 Features

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -8,7 +8,7 @@ In Development
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
-- Wayback will no longer automatically pause and retry when the server returns rate-limit errors. Instead, it will raise a :class:`wayback.exceptions.WaybackRetryError` exception (which includes information how long you should probably pause for in the ``time`` attribute). If you need to keep operating
+- Wayback will no longer automatically pause and retry when the server returns rate-limit errors. Instead, it will raise a :class:`wayback.exceptions.WaybackRetryError` exception (which includes information how long you should probably pause for in the ``time`` attribute).
 
   The previous behavior helped solve some issues with the way rate limits were implemented on the client side that have since been fixed. It was also designed around users who had custom limits on Internet Archive servers, which is an unusual situation. The new approach is safer and can help prevent your IP address from getting blocked. If you need to retry after rate limit errors, make sure your code handles the exception and pauses all requests on all client instances for an appropriate amount of time.
 

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -70,8 +70,8 @@ EMAILISH_URL = re.compile(r'^https?://(<*)((mailto:)|([^/@:]*@))')
 # Make sure it roughly starts with a valid protocol + domain + port?
 URL_ISH = re.compile(r'^[\w+\-]+://[^/?=&]+\.\w\w+(:\d+)?(/|$)')
 
-# How long to delay after a rate limit error if the response does not include a
-# recommended retry time (e.g. via the `Retry-After` header).
+# If a rate limit response (i.e. a response with status == 429) does not
+# include a `Retry-After` header, recommend pausing for this long.
 DEFAULT_RATE_LIMIT_DELAY = 60
 
 
@@ -478,8 +478,8 @@ class WaybackSession(_utils.DisableAfterCloseSession, requests.Session):
     def get_retry_delay(self, retries, response=None):
         delay = 0
 
-        # As of 2023-11-27, the Wayback Machine does not include a `Retry-After`
-        # header on 429 responses, so this parsing is just future-proofing.
+        # As of 2023-11-27, the Wayback Machine does not set a `Retry-After`
+        # header, so this parsing is just future-proofing.
         if response is not None:
             delay = _utils.parse_retry_after(response.headers.get('Retry-After')) or delay
             if response.status_code == 429 and delay == 0:

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -361,7 +361,7 @@ class WaybackSession(_utils.DisableAfterCloseSession, requests.Session):
 
     # It seems Wayback sometimes produces 500 errors for transient issues, so
     # they make sense to retry here. Usually not in other contexts, though.
-    retryable_statuses = frozenset((413, 421, 429, 500, 502, 503, 504, 599))
+    retryable_statuses = frozenset((413, 421, 500, 502, 503, 504, 599))
 
     retryable_errors = (ConnectTimeoutError, MaxRetryError, ReadTimeoutError,
                         ProxyError, RetryError, Timeout)


### PR DESCRIPTION
We used to retry requests that got a response with a 429 status code (indicating that you've hit a rate limit on the server) automatically, but we've resolved that this is no longer a good approach.

See the discussion in https://github.com/edgi-govdata-archiving/wayback/issues/137#issuecomment-1828873225 for more detail, but the short version is that our previous retry behavior was specifically geared to a workflow EDGI used, and which had custom rate limits and other server behavior that most users won't have, and also helped to work around a bunch of deficiencies in our client-side rate limiting that were solved in the last release (but they do need [a *bit* more work](https://github.com/edgi-govdata-archiving/wayback/issues/137#issuecomment-1790980712) in this release, too). It turns out this led to some users getting blocked, and it's better to leave handling this situation to user code.