### PR TITLE
Winter cleaning for rate limiting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,10 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - cache_v8-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-docs.txt" }}
-            - cache_v8-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-            - cache_v8-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-
-            - cache_v8-wayback-<< parameters.python-version >>-{{ arch }}-
+            - cache_v9-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-docs.txt" }}
+            - cache_v9-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            - cache_v9-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-
+            - cache_v9-wayback-<< parameters.python-version >>-{{ arch }}-
 
       - run:
           name: Install Dependencies
@@ -56,7 +56,7 @@ commands:
                   pip install .[docs]
 
       - save_cache:
-          key: cache_v8-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-docs.txt" }}
+          key: cache_v9-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-docs.txt" }}
           paths:
             - ~/venv
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,10 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - cache_v7-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-docs.txt" }}
-            - cache_v7-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-            - cache_v7-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-
-            - cache_v7-wayback-<< parameters.python-version >>-{{ arch }}-
+            - cache_v8-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-docs.txt" }}
+            - cache_v8-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            - cache_v8-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-
+            - cache_v8-wayback-<< parameters.python-version >>-{{ arch }}-
 
       - run:
           name: Install Dependencies
@@ -56,7 +56,7 @@ commands:
                   pip install .[docs]
 
       - save_cache:
-          key: cache_v7-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-docs.txt" }}
+          key: cache_v8-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-docs.txt" }}
           paths:
             - ~/venv
 

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -16,13 +16,33 @@ Breaking Changes
 Features
 ^^^^^^^^
 
-- N/A
+- Rate limiting has been significantly updated under the hood. Separate sessions or clients with customized limits now operate completely independently (their limits previously overlapped in a hard-to-predict way).
+
+  If you need to make multiple :class:`wayback.WaybackSession` instances that share limits, you can create an instance of :class:`wayback.RateLimit` and pass it to each session via the ``*_calls_per_second`` arguments instead of passing an integer or float. For example:
+
+  .. code-block:: python
+
+    # Each of these sessions will be limited to 1 search request every 2
+    # seconds. During a period where only one of these sessions is in use, it
+    # will continue to operate at 1 request every 2 seconds:
+    session1 = WaybackSession(search_calls_per_second=0.5)
+    session2 = WaybackSession(search_calls_per_second=0.5)
+
+    # These sessions will be limited to 1 search request each second as a
+    # combined total. During a period where only one of these sessions is in
+    # use, it will make 1 request per second, but if both are actively in use,
+    # each will make 1 request every 2 seconds:
+    rate = RateLimit(per_second=1)
+    session1 = WaybackSession(search_calls_per_second=rate)
+    session2 = WaybackSession(search_calls_per_second=rate)
+
+  Sessions using the default limits share them via this same mechanism.
 
 
 Fixes & Maintenance
 ^^^^^^^^^^^^^^^^^^^
 
-- N/A
+- The default rate limits have been further tweaked since v0.4.4 based on closer collaboration with Internet Archive staff. Rate limits are also now more accurately applied to each individual request (they were previously applied more roughly, without respect to retries and redirects).
 
 
 v0.4.4 (2023-11-27)

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -129,6 +129,8 @@ Utilities
 
 .. autoclass:: wayback.Mode
 
+.. autoclass:: wayback.RateLimit
+
 Exception Classes
 -----------------
 

--- a/wayback/__init__.py
+++ b/wayback/__init__.py
@@ -2,7 +2,7 @@ from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
-from ._utils import memento_url_data  # noqa
+from ._utils import memento_url_data, RateLimit  # noqa
 
 from ._models import (  # noqa
     CdxRecord,

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -362,7 +362,7 @@ class WaybackSession(_utils.DisableAfterCloseSession, requests.Session):
         A custom user-agent string to use in all requests. Defaults to:
         `wayback/{version} (+https://github.com/edgi-govdata-archiving/wayback)`
     search_calls_per_second : wayback.RateLimit or int or float, default: 0.8
-        The maximum number of calls made to the search API per second.
+        The maximum number of calls per second made to the CDX search API.
         To disable the rate limit, set this to 0.
 
         To have multiple sessions share a rate limit (so requests made by one
@@ -371,7 +371,17 @@ class WaybackSession(_utils.DisableAfterCloseSession, requests.Session):
         ``WaybackSession`` instance. If you do not set a limit, the default
         limit is shared globally across all sessions.
     memento_calls_per_second : wayback.RateLimit or int or float, default: 8
-        The maximum number of calls made to the memento API per second.
+        The maximum number of calls per second made to the memento API.
+        To disable the rate limit, set this to 0.
+
+        To have multiple sessions share a rate limit (so requests made by one
+        session count towards the limit of the other session), use a
+        single :class:`wayback.RateLimit` instance and pass it to each
+        ``WaybackSession`` instance. If you do not set a limit, the default
+        limit is shared globally across all sessions.
+    timemap_calls_per_second : wayback.RateLimit or int or float, default: 1.33
+        The maximum number of calls per second made to the timemap API (the
+        Wayback Machine's new, beta CDX search is part of the timemap API).
         To disable the rate limit, set this to 0.
 
         To have multiple sessions share a rate limit (so requests made by one

--- a/wayback/_client.py
+++ b/wayback/_client.py
@@ -148,6 +148,10 @@ def is_malformed_url(url):
     return False
 
 
+def is_memento_response(response):
+    return 'Memento-Datetime' in response.headers
+
+
 def cdx_hash(content):
     if isinstance(content, str):
         content = content.encode()
@@ -476,7 +480,7 @@ class WaybackSession(_utils.DisableAfterCloseSession, requests.Session):
 
     def should_retry(self, response):
         # A memento may actually be a capture of an error, so don't retry it :P
-        if 'Memento-Datetime' in response.headers:
+        if is_memento_response(response):
             return False
 
         return response.status_code in self.retryable_statuses
@@ -1007,7 +1011,7 @@ class WaybackClient(_utils.DepthCountedContext):
                             '%a, %d %b %Y %H:%M:%S %Z'
                         )
 
-                is_memento = 'Memento-Datetime' in response.headers
+                is_memento = is_memento_response(response)
 
                 # A memento URL will match possible captures based on its SURT
                 # form, which means we might be getting back a memento captured

--- a/wayback/_utils.py
+++ b/wayback/_utils.py
@@ -8,6 +8,7 @@ import requests
 import requests.adapters
 import threading
 import time
+from typing import Union
 import urllib.parse
 from .exceptions import SessionClosedError
 
@@ -270,6 +271,17 @@ class RateLimit:
 
     def __exit__(self, type, value, traceback):
         pass
+
+    @classmethod
+    def make_limit(cls, per_second: Union['RateLimit',  int, float]) -> 'RateLimit':
+        """
+        If the given rate is a ``RateLimit`` object, return it unchanged.
+        Otherwise, create a new ``RateLimit`` with the given rate.
+        """
+        if isinstance(per_second, cls):
+            return per_second
+        else:
+            return cls(per_second)
 
 
 class DepthCountedContext:

--- a/wayback/_utils.py
+++ b/wayback/_utils.py
@@ -1,6 +1,5 @@
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict
 from collections.abc import Mapping, MutableMapping
-from contextlib import contextmanager
 from datetime import date, datetime, timezone
 import email.utils
 import logging

--- a/wayback/_utils.py
+++ b/wayback/_utils.py
@@ -246,7 +246,11 @@ class RateLimit:
     >>>     with limit:
     >>>         print(x)
     """
-    def __init__(self, per_second):
+    def __init__(self, per_second: Union[int, float]):
+        if not isinstance(per_second, (int, float)):
+            raise TypeError('The RateLimit per_second argument must be an int '
+                            f'or float, not {type(per_second).__name__}')
+
         self._lock = threading.RLock()
         self._last_call_time = 0
         if per_second <= 0:
@@ -254,7 +258,7 @@ class RateLimit:
         else:
             self._minimum_wait = 1.0 / per_second
 
-    def wait(self):
+    def wait(self) -> None:
         if self._minimum_wait == 0:
             return
 
@@ -266,10 +270,10 @@ class RateLimit:
 
             self._last_call_time = time.time()
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         self.wait()
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, type, value, traceback) -> None:
         pass
 
     @classmethod

--- a/wayback/_utils.py
+++ b/wayback/_utils.py
@@ -221,38 +221,56 @@ def set_memento_url_mode(url, mode):
     return format_memento_url(captured_url, timestamp, mode)
 
 
-_last_call_by_group = defaultdict(int)
-_rate_limit_lock = threading.Lock()
-
-
-@contextmanager
-def rate_limited(calls_per_second=1, group='default'):
+class RateLimit:
     """
-    A context manager that restricts entries to its body to occur only N times
-    per second (N can be a float). The current thread will be put to sleep in
-    order to delay calls.
+    ``RateLimit`` is a simple locking mechanism that can be used to enforce
+    rate limits and is safe to use across multiple threads. It can also be used
+    as a context manager.
+
+    Calling `rate_limit_instance.wait()` blocks until a minimum time has passed
+    since the last call. Using `with rate_limit_instance:` blocks entries to
+    the context until a minimum time since the last context entry.
 
     Parameters
     ----------
-    calls_per_second : float or int, default: 2
-        Maximum number of calls into this context allowed per second
-    group : string, default: 'default'
-        Unique name to scope rate limiting. If two contexts have different
-        `group` values, their timings will be tracked separately.
+    per_second : int or float
+        The maximum number of calls per second that are allowed. If 0, a call
+        to `wait()` will never block.
+
+    Examples
+    --------
+    Slow down a tight loop to only occur twice per second:
+
+    >>> limit = RateLimit(per_second=2)
+    >>> for x in range(10):
+    >>>     with limit:
+    >>>         print(x)
     """
-    if calls_per_second <= 0:
-        yield
-    else:
-        with _rate_limit_lock:
-            last_call = _last_call_by_group[group]
-            minimum_wait = 1.0 / calls_per_second
+    def __init__(self, per_second):
+        self._lock = threading.RLock()
+        self._last_call_time = 0
+        if per_second <= 0:
+            self._minimum_wait = 0
+        else:
+            self._minimum_wait = 1.0 / per_second
+
+    def wait(self):
+        if self._minimum_wait == 0:
+            return
+
+        with self._lock:
             current_time = time.time()
-            if current_time - last_call < minimum_wait:
-                seconds = minimum_wait - (current_time - last_call)
-                logger.debug('Hit %s rate limit, sleeping for %s seconds', group, seconds)
-                time.sleep(seconds)
-            _last_call_by_group[group] = time.time()
-        yield
+            idle_time = current_time - self._last_call_time
+            if idle_time < self._minimum_wait:
+                time.sleep(self._minimum_wait - idle_time)
+
+            self._last_call_time = time.time()
+
+    def __enter__(self):
+        self.wait()
+
+    def __exit__(self, type, value, traceback):
+        pass
 
 
 class DepthCountedContext:

--- a/wayback/tests/test_client.py
+++ b/wayback/tests/test_client.py
@@ -792,7 +792,7 @@ class TestWaybackSession:
                 next(client.search('zew.de'))
         duration_with_limits_custom = time.time() - start_time
 
-        assert 1.9 <= duration_with_limits <= 2.1
+        assert 2.4 <= duration_with_limits <= 2.6
         assert 0.0 <= duration_without_limits <= 0.05
         assert 0.0 <= duration_with_limits_custom <= 1.05
 
@@ -828,6 +828,6 @@ class TestWaybackSession:
                 client.get_memento(cdx)
         duration_with_limits_custom = time.time() - start_time
 
-        assert 0.33 <= duration_with_limits <= 0.43
+        assert 1.15 <= duration_with_limits <= 1.35
         assert 0.0 <= duration_without_limits <= 0.05
         assert 0.5 <= duration_with_limits_custom <= 0.55


### PR DESCRIPTION
This significantly refactors how we manage rate limiting with the goal of making it more clear, flexible, and accurate going forward. It encompasses a few major changes:

- [x] **Set limits based on actual values from Internet Archive sysadmins.** We previously determined rate limits via a combination of ad-hoc conversations with Internet Archive staff, our own testing, and feedback from users. I’ve made special effort to reach out to Internet Archive staff and get explicit feedback about both the hard limits and their desired default behavior (80% of hard limits).

- [x] **Replace `rate_limited()` with a `RateLimit` class.** This allows separate sessions to share limits or operate with independent limits in a clearer way. Previously, multiple sessions with different limits would still interact in complicated ways. Limits previously acted more like “how long do I wait after the previous request (from any session, even if it had a different limit).” Now sessions with different limit objects operate completely independently, and sessions that need to share limits can share instances of `RateLimit`.

    The default limits are globally shared `RateLimit` objects, so multiple sessions without explicitly set limits will still coordinate their limiting together just like they used to.

- [x] **Move rate limit application from the client to the session.** We previously applied the rate limits from the client inside the `search()` and `get_memento()` methods. Instead, we’ll apply them inside `WaybackSession.send()`. This ensures that they are always applied (harder to make mistakes) and also fixes an issue where we did no limit following redirects in mementos. The rate limits also belong to the session, so the session is really the right place to apply them anyway.

- [x] Update release notes draft.

Fixes #137.

Some of this also hopefully paves the way for an even bigger refactor of `WaybackSession` in #58.