### PR TITLE
Do PyPI release in GHA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,5 +130,4 @@ workflows:
               python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
               urllib3-version: ["1.20", "2.0"]
       - lint
-      - build
       - docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,27 +101,6 @@ jobs:
             . ~/venv/bin/activate
             flake8 .
 
-  build:
-    working_directory: ~/wayback
-    docker:
-      - image: cimg/python:3.12
-    steps:
-      - checkout
-      - setup_pip:
-          python-version: "3.12"
-          install-dev: true
-      - run:
-          name: Build Distribution
-          command: |
-            . ~/venv/bin/activate
-            python -m build .
-      - run:
-          name: Check Distribution
-          command: |
-            . ~/venv/bin/activate
-            twine check dist/*
-            check-wheel-contents dist
-
   # NOTE: The docs are mainly built and published directly by readthedocs.com.
   # This job is meant to verify there are no issues with the docs and it is NOT
   # responsible for building what actually gets published. (Readthedocs.com

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,8 +1,8 @@
 name: CD
 
 on:
-  workflow_dispatch:
-  pull_request:
+  workflow_dispatch: {}
+  pull_request: {}
   push:
     branches:
       - main

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,38 @@
+name: CD
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+jobs:
+  dist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: hynek/build-and-inspect-python-package@v1
+
+  publish:
+    needs: [dist]
+    environment: pypi
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: Packages
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: hynek/build-and-inspect-python-package@v1
+      - uses: hynek/build-and-inspect-python-package@v2
 
   publish:
     needs: [dist]
@@ -29,7 +29,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: Packages
           path: dist


### PR DESCRIPTION
Precisely following https://learn.scientific-python.org/development/guides/gha-pure/

This introduces GHA, alongside CircleCI. An additional integration is not ideal, bu there are points in favor:

* GHA, being a GH-internal integration, is not a big jump to make.
* We can use this community-supported recipe as is.
* GHA can handshake directly with PyPI via [Trusted Publisher](https://docs.pypi.org/trusted-publishers/) that we do not need to handle secrets in the environment. (It seems like it ought to be possible to do this with CircleCI, but some cursory Googling did not turn anything up.)