### PR TITLE
Remove `requests` from public interfaces

### DIFF
--- a/src/wayback/_client.py
+++ b/src/wayback/_client.py
@@ -272,8 +272,8 @@ def clean_memento_links(links, mode):
 
 class WaybackSession(_utils.DisableAfterCloseSession):
     """
-    A custom session object that pools network connections and resources for
-    requests to the Wayback Machine.
+    Sessions manage HTTP requests and network traffic to web servers, adding
+    functionality like retries and rate limiting.
 
     Parameters
     ----------
@@ -463,7 +463,7 @@ class WaybackSession(_utils.DisableAfterCloseSession):
 
 
 # TODO: add retry, backoff, cross_thread_backoff, and rate_limit options that
-# create a custom instance of urllib3.utils.Retry
+# create a custom instance of urllib3.utils.Retry?
 class WaybackClient(_utils.DepthCountedContext):
     """
     A client for retrieving data from the Internet Archive's Wayback Machine.

--- a/src/wayback/_client.py
+++ b/src/wayback/_client.py
@@ -28,13 +28,13 @@ from requests.exceptions import (ChunkedEncodingError,
                                  Timeout)
 import time
 from urllib.parse import urljoin, urlparse
-from urllib3.connectionpool import HTTPConnectionPool
 from urllib3.exceptions import (ConnectTimeoutError,
                                 MaxRetryError,
                                 ReadTimeoutError)
 from warnings import warn
 from . import _utils, __version__
 from ._models import CdxRecord, Memento
+from ._http import *  # noqa
 from .exceptions import (WaybackException,
                          UnexpectedResponseFormat,
                          BlockedByRobotsError,
@@ -269,71 +269,6 @@ def clean_memento_links(links, mode):
             result[key] = value
 
     return result
-
-
-#####################################################################
-# HACK: handle malformed Content-Encoding headers from Wayback.
-# When you send `Accept-Encoding: gzip` on a request for a memento, Wayback
-# will faithfully gzip the response body. However, if the original response
-# from the web server that was snapshotted was gzipped, Wayback screws up the
-# `Content-Encoding` header on the memento response, leading any HTTP client to
-# *not* decompress the gzipped body. Wayback folks have no clear timeline for
-# a fix, hence the workaround here.
-#
-# More info in this issue:
-# https://github.com/edgi-govdata-archiving/web-monitoring-processing/issues/309
-#
-# Example broken Wayback URL:
-# http://web.archive.org/web/20181023233237id_/http://cwcgom.aoml.noaa.gov/erddap/griddap/miamiacidification.graph
-#
-if hasattr(HTTPConnectionPool, 'ResponseCls'):
-    # urllib3 v1.x:
-    #
-    # This subclass of urllib3's response class identifies the malformed headers
-    # and repairs them before instantiating the actual response object, so when
-    # it reads the body, it knows to decode it correctly.
-    #
-    # See what we're overriding from urllib3:
-    # https://github.com/urllib3/urllib3/blob/a6ec68a5c5c5743c59fe5c62c635c929586c429b/src/urllib3/response.py#L499-L526
-    class WaybackResponse(HTTPConnectionPool.ResponseCls):
-        @classmethod
-        def from_httplib(cls, httplib_response, **response_kwargs):
-            headers = httplib_response.msg
-            pairs = headers.items()
-            if ('content-encoding', '') in pairs and ('Content-Encoding', 'gzip') in pairs:
-                del headers['content-encoding']
-                headers['Content-Encoding'] = 'gzip'
-            return super().from_httplib(httplib_response, **response_kwargs)
-
-    HTTPConnectionPool.ResponseCls = WaybackResponse
-else:
-    # urllib3 v2.x:
-    #
-    # Unfortunately, we can't wrap the `HTTPConnection.getresponse` method in
-    # urllib3 v2, since it may have read the response body before returning. So
-    # we patch the HTTPHeaderDict class instead.
-    from urllib3._collections import HTTPHeaderDict as Urllib3HTTPHeaderDict
-    _urllib3_header_init = Urllib3HTTPHeaderDict.__init__
-
-    def _new_header_init(self, headers=None, **kwargs):
-        if headers:
-            if isinstance(headers, (Urllib3HTTPHeaderDict, dict)):
-                pairs = list(headers.items())
-            else:
-                pairs = list(headers)
-            if (
-                ('content-encoding', '') in pairs and
-                ('Content-Encoding', 'gzip') in pairs
-            ):
-                headers = [pair for pair in pairs
-                           if pair[0].lower() != 'content-encoding']
-                headers.append(('Content-Encoding', 'gzip'))
-
-        return _urllib3_header_init(self, headers, **kwargs)
-
-    Urllib3HTTPHeaderDict.__init__ = _new_header_init
-# END HACK
-#####################################################################
 
 
 class WaybackSession(_utils.DisableAfterCloseSession, requests.Session):

--- a/src/wayback/_client.py
+++ b/src/wayback/_client.py
@@ -31,7 +31,7 @@ from urllib3.exceptions import (ConnectTimeoutError,
 from warnings import warn
 from . import _utils, __version__
 from ._models import CdxRecord, Memento
-from ._http import InternalHttpResponse, WaybackHttpAdapter
+from ._http import WaybackHttpResponse, WaybackHttpAdapter
 from .exceptions import (WaybackException,
                          UnexpectedResponseFormat,
                          BlockedByRobotsError,
@@ -145,7 +145,7 @@ def is_malformed_url(url):
     return False
 
 
-def is_memento_response(response: InternalHttpResponse) -> bool:
+def is_memento_response(response: WaybackHttpResponse) -> bool:
     return 'Memento-Datetime' in response.headers
 
 
@@ -354,7 +354,7 @@ class WaybackSession(_utils.DisableAfterCloseSession):
         # with Wayback's APIs, but urllib3 logs a warning on every retry:
         # https://github.com/urllib3/urllib3/blob/5b047b645f5f93900d5e2fc31230848c25eb1f5f/src/urllib3/connectionpool.py#L730-L737
 
-    def request(self, method, url, timeout=-1, **kwargs) -> InternalHttpResponse:
+    def request(self, method, url, timeout=-1, **kwargs) -> WaybackHttpResponse:
         super().request()
         start_time = time.time()
         timeout = self.timeout if timeout is -1 else timeout

--- a/src/wayback/_http.py
+++ b/src/wayback/_http.py
@@ -3,7 +3,11 @@ HTTP tooling used by Wayback when making requests to and handling responses
 from Wayback Machine servers.
 """
 
+import logging
+import requests
 from urllib3.connectionpool import HTTPConnectionPool
+
+logger = logging.getLogger(__name__)
 
 #####################################################################
 # HACK: handle malformed Content-Encoding headers from Wayback.
@@ -68,3 +72,34 @@ else:
     Urllib3HTTPHeaderDict.__init__ = _new_header_init
 # END HACK
 #####################################################################
+
+
+class WaybackHttpAdapter:
+    """
+    TODO
+    """
+
+    def __init__(self) -> None:
+        self._session = requests.Session()
+
+    def request(
+        self,
+        method,
+        url,
+        *,
+        params=None,
+        headers=None,
+        allow_redirects=True,
+        timeout=None
+    ) -> requests.Response:
+        return self._session.request(
+            method=method,
+            url=url,
+            params=params,
+            headers=headers,
+            allow_redirects=allow_redirects,
+            timeout=timeout
+        )
+
+    def close(self):
+        self._session.close()

--- a/src/wayback/_http.py
+++ b/src/wayback/_http.py
@@ -4,7 +4,12 @@ from Wayback Machine servers.
 """
 
 import logging
+import threading
+from typing import Optional
+from urllib.parse import urljoin
 import requests
+from requests.exceptions import (ChunkedEncodingError,
+                                 ContentDecodingError)
 from urllib3.connectionpool import HTTPConnectionPool
 
 logger = logging.getLogger(__name__)
@@ -74,6 +79,108 @@ else:
 #####################################################################
 
 
+# FIXME: This implementation is tied to requests. It should probably be an
+# abstract base class and we should have a requests-specific implementation,
+# which would make `WaybackHttpAdapter` customizable/pluggable.
+class InternalHttpResponse:
+    """
+    Internal wrapper class for HTTP responses. _This should never be exposed to
+    user code_; it's job is to insulate the rest of the Wayback package from
+    the particulars of the underlying HTTP tooling (e.g. requests, httpx, etc).
+    This is *similar* to response objects from httpx and requests, although it
+    lacks facilities from those libraries that we don't need or use, and takes
+    shortcuts that are specific to our use cases.
+    """
+    status_code: int
+    headers: dict
+    encoding: Optional[str] = None
+    url: str
+    links: dict
+    _read_lock: threading.Lock
+    _raw: object
+    _content: Optional[bytes] = None
+    _redirect_url: Optional[str] = None
+
+    def __init__(self, raw: requests.Response, request_url: str) -> None:
+        self._read_lock = threading.Lock()
+        self._raw = raw
+        self.status_code = raw.status_code
+        self.headers = raw.headers
+        self.url = urljoin(request_url, getattr(raw, 'url', ''))
+        self.encoding = raw.encoding
+        self.links = raw.links
+
+    @property
+    def content(self) -> bytes:
+        with self._read_lock:
+            if self._content is None:
+                # TODO: This is designed around the requests library and is not
+                # generic enough. A better version would either:
+                # 1. Leave this for subclasses to implement.
+                # 2. Read iteratively from a `raw` object with a `read(n)` method.
+                self._content = self._raw.content
+
+            return self._content
+
+    @property
+    def text(self) -> str:
+        encoding = self.encoding or self.sniff_encoding() or 'utf-8'
+        try:
+            return str(self.content, encoding, errors="replace")
+        except (LookupError, TypeError):
+            return str(self.content, errors="replace")
+
+    def sniff_encoding(self) -> None:
+        # XXX: requests uses chardet here. Consider what we want to use.
+        ...
+
+    @property
+    def redirect_url(self) -> str:
+        """
+        The URL this response redirects to. If the response is not a redirect,
+        this returns an empty string.
+        """
+        if self.status_code >= 300 and self.status_code < 400:
+            location = self.headers.get('location')
+            if location:
+                return urljoin(self.url, location)
+
+        return ''
+
+    @property
+    def is_success(self) -> bool:
+        return self.status_code >= 200 and self.status_code < 300
+
+    # XXX: This needs wrapping with a lock! (Maybe `_read_lock` should be an
+    # RLock so it can be used both here and in `content`).
+    def close(self, cache: bool = True) -> None:
+        """
+        Read the rest of the response off the wire and release the connection.
+        If the full response is not read, the connection can hang and programs
+        will leak memory (and cause a bad time for the server as well).
+
+        Parameters
+        ----------
+        cache : bool, default: True
+            Whether to cache the response body so it can still be used via the
+            ``content`` and ``text`` properties.
+        """
+        if self._raw:
+            try:
+                # TODO: if cache is false, it would be better not to try and
+                # read content at all.
+                self.content
+                if not cache:
+                    self._content = ''
+            except (ChunkedEncodingError, ContentDecodingError, RuntimeError):
+                with self._read_lock:
+                    self._raw.read(decode_content=False)
+            finally:
+                with self._read_lock:
+                    self._raw.close()
+                    self._raw = None
+
+
 class WaybackHttpAdapter:
     """
     TODO
@@ -91,8 +198,8 @@ class WaybackHttpAdapter:
         headers=None,
         allow_redirects=True,
         timeout=None
-    ) -> requests.Response:
-        return self._session.request(
+    ) -> InternalHttpResponse:
+        response = self._session.request(
             method=method,
             url=url,
             params=params,
@@ -100,6 +207,7 @@ class WaybackHttpAdapter:
             allow_redirects=allow_redirects,
             timeout=timeout
         )
+        return InternalHttpResponse(response, url)
 
     def close(self):
         self._session.close()

--- a/src/wayback/_http.py
+++ b/src/wayback/_http.py
@@ -1,0 +1,70 @@
+"""
+HTTP tooling used by Wayback when making requests to and handling responses
+from Wayback Machine servers.
+"""
+
+from urllib3.connectionpool import HTTPConnectionPool
+
+#####################################################################
+# HACK: handle malformed Content-Encoding headers from Wayback.
+# When you send `Accept-Encoding: gzip` on a request for a memento, Wayback
+# will faithfully gzip the response body. However, if the original response
+# from the web server that was snapshotted was gzipped, Wayback screws up the
+# `Content-Encoding` header on the memento response, leading any HTTP client to
+# *not* decompress the gzipped body. Wayback folks have no clear timeline for
+# a fix, hence the workaround here.
+#
+# More info in this issue:
+# https://github.com/edgi-govdata-archiving/web-monitoring-processing/issues/309
+#
+# Example broken Wayback URL:
+# http://web.archive.org/web/20181023233237id_/http://cwcgom.aoml.noaa.gov/erddap/griddap/miamiacidification.graph
+#
+if hasattr(HTTPConnectionPool, 'ResponseCls'):
+    # urllib3 v1.x:
+    #
+    # This subclass of urllib3's response class identifies the malformed headers
+    # and repairs them before instantiating the actual response object, so when
+    # it reads the body, it knows to decode it correctly.
+    #
+    # See what we're overriding from urllib3:
+    # https://github.com/urllib3/urllib3/blob/a6ec68a5c5c5743c59fe5c62c635c929586c429b/src/urllib3/response.py#L499-L526
+    class WaybackUrllib3Response(HTTPConnectionPool.ResponseCls):
+        @classmethod
+        def from_httplib(cls, httplib_response, **response_kwargs):
+            headers = httplib_response.msg
+            pairs = headers.items()
+            if ('content-encoding', '') in pairs and ('Content-Encoding', 'gzip') in pairs:
+                del headers['content-encoding']
+                headers['Content-Encoding'] = 'gzip'
+            return super().from_httplib(httplib_response, **response_kwargs)
+
+    HTTPConnectionPool.ResponseCls = WaybackUrllib3Response
+else:
+    # urllib3 v2.x:
+    #
+    # Unfortunately, we can't wrap the `HTTPConnection.getresponse` method in
+    # urllib3 v2, since it may have read the response body before returning. So
+    # we patch the HTTPHeaderDict class instead.
+    from urllib3._collections import HTTPHeaderDict as Urllib3HTTPHeaderDict
+    _urllib3_header_init = Urllib3HTTPHeaderDict.__init__
+
+    def _new_header_init(self, headers=None, **kwargs):
+        if headers:
+            if isinstance(headers, (Urllib3HTTPHeaderDict, dict)):
+                pairs = list(headers.items())
+            else:
+                pairs = list(headers)
+            if (
+                ('content-encoding', '') in pairs and
+                ('Content-Encoding', 'gzip') in pairs
+            ):
+                headers = [pair for pair in pairs
+                           if pair[0].lower() != 'content-encoding']
+                headers.append(('Content-Encoding', 'gzip'))
+
+        return _urllib3_header_init(self, headers, **kwargs)
+
+    Urllib3HTTPHeaderDict.__init__ = _new_header_init
+# END HACK
+#####################################################################

--- a/src/wayback/_utils.py
+++ b/src/wayback/_utils.py
@@ -4,8 +4,6 @@ from datetime import date, datetime, timezone
 import email.utils
 import logging
 import re
-import requests
-import requests.adapters
 import threading
 import time
 from typing import Union

--- a/src/wayback/_utils.py
+++ b/src/wayback/_utils.py
@@ -322,7 +322,7 @@ class DepthCountedContext:
         pass
 
 
-class DisableAfterCloseSession(requests.Session):
+class DisableAfterCloseSession:
     """
     A custom session object raises a :class:`SessionClosedError` if you try to
     use it after closing it, to help identify and avoid potentially dangerous
@@ -332,16 +332,13 @@ class DisableAfterCloseSession(requests.Session):
     _closed = False
 
     def close(self, disable=True):
-        super().close()
         if disable:
             self._closed = True
 
-    def send(self, *args, **kwargs):
+    def request(self, *args, **kwargs):
         if self._closed:
             raise SessionClosedError('This session has already been closed '
                                      'and cannot send new HTTP requests.')
-
-        return super().send(*args, **kwargs)
 
 
 class CaseInsensitiveDict(MutableMapping):

--- a/src/wayback/tests/test_client.py
+++ b/src/wayback/tests/test_client.py
@@ -694,7 +694,7 @@ class TestWaybackSession:
                                               {'text': 'good', 'status_code': 200}])
         session = WaybackSession(retries=2, backoff=0.1)
         response = session.request('GET', 'http://test.com')
-        assert response.ok
+        assert response.is_success
 
         session.close()
 


### PR DESCRIPTION
`WaybackSession` was originally a subclass of `requests.Session`, and that turns out to have been a poor decision (see https://github.com/edgi-govdata-archiving/wayback/pull/152#issuecomment-1858800671). We wanted to make customizing HTTP behavior relatively straightforward, but using a subclass-able version of `requests.Session` wound up baking problematic parts of requests into our API. In particular, requests is not thread-safe and this setup makes it hard to wrap with thread-safe code. We also unintentionally broke the promise of easy subclassing when we added complex retry and rate limiting behavior.

This is a major, breaking change designed to largely remove requests from our public API:

- `WaybackSession` is now its own, standalone class instead of a subclass of `requests.Session`. It handles stuff like rate limiting, retries, etc.

- `WaybackHttpAdapter` handles making a single HTTP request and is the interface through which we use the requests library.
    - It has a very small API (2 methods: `.request()` sends an HTTP request; `.close()` closes all its network connections).

    - The `.request()` method returns a `WaybackHttpResponse` object, which models just the parts of the response we need. The `WaybackHttpResponse` class is an abstract base class that represents the API that the rest of Wayback needs, and internally we have a `WaybackRequestsResponse` subclass that wraps a response object from Requests in a thread-safe way.

    - Ideally, the small API will make it easy for us to build an alternate implementation with urllib3, httpx, etc, or just to add thread-safe handling of requests. It might also be a better way to let users customize HTTP behavior than the old approach, although you can’t yet supply a custom subclass to `WaybackClient` or `WaybackSession`.

❗ **Open question:** I don’t think that `WaybackSession` should continue to exist. It makes the API complex and it lets the details of requests leak out a little bit through exception handling. Any feedback on this is welcome (cc @danielballan). Some ideas:

1. Move its functionality directly into `WaybackHttpAdapter`.
    - Upside: this gets all the requests stuff — including exception handling — tucked away into one place.
    - Downside: Safely customizing `WaybackHttpAdapter` gets more complex because you have to work around all that machinery. It’s not as straightforward as just overriding the `.request()` method. Some ways to address that:
        - Add a `WaybackHttpAdapter._request()` method (not the underscore) that you can override if you just want to customize the sending of a single HTTP request.
        - Re-architect that functionality into some kind of service/helper object that you can use from a customized `WaybackHttpAdapter` subclass. I think this might be a lot more work than it's worth, though.

2. Move its functionality into `WaybackClient`.
    - Upside: keeps all the things that are special about dealing with HTTP requests at a high level out of the lower-level adapter tooling. Keeps adapters as simple as possible.
    - Downside: Lets some exception handling that is specific to requests leak out into the rest of the package. Makes it harder to change that behavior. What if httpx or some other tool incorporates rate limiting in the future? It would be nice to let an adapter delegate those tasks to the lower-level tool it is acting as glue for.

I think I’m leaning towards some version of (1) here.

This paves the way towards fixing #58, but does not actually solve the issue (`WaybackHttpAdapter` is not yet thread-safe, and needs to use some of the tricks from #23).