### PR TITLE
Run tests on Python 3.13.0rc1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ workflows:
           matrix:
             parameters:
               base-image: ["mr0grog/circle-python-pre"]
-              python-version: ["3.13.0b2"]
+              python-version: ["3.13.0rc1"]
               urllib3-version: ["1.20", "2.0"]
       - lint
       - docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ workflows:
           matrix:
             parameters:
               base-image: ["mr0grog/circle-python-pre"]
-              python-version: ["3.13.0rc1"]
+              python-version: ["3.13.0rc1", "3.13.0rc1t"]
               urllib3-version: ["1.20", "2.0"]
       - lint
       - docs


### PR DESCRIPTION
Update tests to run on Python 3.13.0rc1, which has now been released.