### PR TITLE
Test on production Python 3.14.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ workflows:
           matrix:
             parameters:
               base-image: ["mr0grog/circle-python-pre"]
-              python-version: ["3.14.0rc3", "3.14.0rc3t"]
+              python-version: ["3.14.0", "3.14.0t"]
               urllib3-version: ["1.20", "2.0"]
       - lint
       - docs


### PR DESCRIPTION
Python 3.14.0 is now out, although Circle does not yet have an image, so this still uses an image from the pre-release Docker repo.