### PR TITLE
Update licensing info per PEP 639

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,7 @@ Thanks to the following people for their contributions and help on this package!
 
 - `Dan Allan <https://github.com/danielballan>`_ (Code, Tests, Documentation, Reviews)
 - `Rob Brackett <https://github.com/Mr0grog>`_ (Code, Tests, Documentation, Reviews)
+- `Derzan Chiang <https://github.com/MiTo0o>`_ (Documentation)
 - `David Gilman <https://github.com/dgilman>`_ (Documentation)
 - `Will Sackfield <https://github.com/8W9aG>`_ (Code, Tests)
 - `Ed Summers <https://github.com/edsu>`_ (Code, Tests)

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -5,6 +5,9 @@ Release History
 (In Development)
 ----------------
 
+- Updated license identifier to follow PEP 639 style. This should make sure the license is surfaced better and more clearly on PyPI. (:issue:`186`)
+
+
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,12 @@ maintainers = [
 ]
 # TODO: put contributors in `authors` field?
 #   authors = [ { name="XYZ" }, ... ]
-license = {text = "BSD (3-clause)"}
+license = "BSD-3-Clause"
 requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
-    # It would be nice to have a license classifier here, but there isn't one:
-    # https://github.com/pypa/trove-classifiers/issues/70
 ]
 dependencies = [
   "requests",


### PR DESCRIPTION
Updated the project.license field to the SPDX identifier "BSD-3-Clause" per PEP 639 and removed the outdated Trove classifier comment. Verified locally by building the wheel that the build backend automatically includes the LICENSE file in the .dist-info directory, so an explicit license-files array is not needed. Closes #168 