### PR TITLE
Rename CdxRecord fields to align with CDX server names (#130)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Thanks to the following people for their contributions and help on this package!
 
 - `Dan Allan <https://github.com/danielballan>`_ (Code, Tests, Documentation, Reviews)
 - `Rob Brackett <https://github.com/Mr0grog>`_ (Code, Tests, Documentation, Reviews)
-- `Derzan Chiang <https://github.com/MiTo0o>`_ (Documentation)
+- `Derzan Chiang <https://github.com/MiTo0o>`_ (Code, Tests, Documentation)
 - `David Gilman <https://github.com/dgilman>`_ (Documentation)
 - `Will Sackfield <https://github.com/8W9aG>`_ (Code, Tests)
 - `Ed Summers <https://github.com/edsu>`_ (Code, Tests)

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -46,6 +46,7 @@ Features
 - Several attributes of :class:`wayback.CdxRecord` have been renamed to match their names in Wayback's actual CDX API. The old names still work for now, but using them will log a deprecation warning. We plan to remove them entirely in a future release. (:issue:`187`)
 
   The renamed attributes are:
+
   - ``key`` (now ``urlkey``).
   - ``url`` (now ``original``).
   - ``mime_type`` (now ``mimetype``).

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -43,6 +43,14 @@ Features
 
   Sessions using the default limits share them via this same mechanism.
 
+- Several attributes of :class:`wayback.CdxRecord` have been renamed to match their names in Wayback's actual CDX API. The old names still work for now, but using them will log a deprecation warning. We plan to remove them entirely in a future release. (:issue:`187`)
+
+  The renamed attributes are:
+  - ``key`` (now ``urlkey``).
+  - ``url`` (now ``original``).
+  - ``mime_type`` (now ``mimetype``).
+  - ``status_code`` (now ``statuscode``).
+
 
 Fixes & Maintenance
 ^^^^^^^^^^^^^^^^^^^

--- a/src/wayback/_client.py
+++ b/src/wayback/_client.py
@@ -818,44 +818,38 @@ class WaybackClient(_utils.DepthCountedContext):
                     previous_result = text
 
                 try:
-                    data = CdxRecord(*text.split(' '), '', '')
-                    if data.status_code == '-':
-                        # the status code given for a revisit record
-                        status_code = None
-                    else:
-                        status_code = int(data.status_code)
-                    length = None if data.length == '-' else int(data.length)
-                    capture_time = _utils.parse_timestamp(data.timestamp)
+                    # The CDX server returns 7 fields:
+                    # urlkey, timestamp, original, mimetype, statuscode, digest, length
+                    (urlkey, raw_timestamp, original, mimetype,
+                     raw_status, digest, raw_length) = text.split(' ')
+
+                    statuscode = None if raw_status == '-' else int(raw_status)
+                    length = None if raw_length == '-' else int(raw_length)
+                    timestamp = _utils.parse_timestamp(raw_timestamp)
                 except Exception as err:
                     if 'RobotAccessControlException' in text:
                         raise BlockedByRobotsError(query["url"])
                     raise UnexpectedResponseFormat(
                         f'Could not parse CDX output: "{text}" (query: {sent_query})') from err
 
-                clean_url = REDUNDANT_HTTPS_PORT.sub(
+                original = REDUNDANT_HTTPS_PORT.sub(
                     r'\1\2', REDUNDANT_HTTP_PORT.sub(
-                        r'\1\2', data.url))
-                if skip_malformed_results and is_malformed_url(clean_url):
+                        r'\1\2', original))
+                if skip_malformed_results and is_malformed_url(original):
                     continue
-                if clean_url != data.url:
-                    data = data._replace(url=clean_url)
 
                 # TODO: repeat captures have a status code of `-` and a mime type
                 # of `warc/revisit`. These can only be resolved by requesting the
                 # content and following redirects. Maybe nice to do so
                 # automatically here.
-                data = data._replace(
-                    status_code=status_code,
-                    length=length,
-                    timestamp=capture_time,
-                    raw_url=_utils.format_memento_url(
-                        url=data.url,
-                        timestamp=data.timestamp,
-                        mode=Mode.original.value),
-                    view_url=_utils.format_memento_url(
-                        url=data.url,
-                        timestamp=data.timestamp,
-                        mode=Mode.view.value)
+                data = CdxRecord(
+                    urlkey=urlkey,
+                    timestamp=timestamp,
+                    original=original,
+                    mimetype=mimetype,
+                    statuscode=statuscode,
+                    digest=digest,
+                    length=length
                 )
                 count += 1
                 yield data

--- a/src/wayback/_client.py
+++ b/src/wayback/_client.py
@@ -15,7 +15,6 @@ Other potentially useful links:
 
 from base64 import b32encode
 from datetime import date
-from enum import Enum
 import hashlib
 import logging
 import re
@@ -34,7 +33,7 @@ from urllib3.exceptions import (ConnectTimeoutError,
                                 ReadTimeoutError)
 from warnings import warn
 from . import _utils, __version__
-from ._models import CdxRecord, Memento
+from ._models import CdxRecord, Memento, Mode
 from .exceptions import (WaybackException,
                          UnexpectedResponseFormat,
                          BlockedByRobotsError,
@@ -79,59 +78,6 @@ DEFAULT_MEMENTO_RATE_LIMIT = _utils.RateLimit(0.8 * 600 / 60)
 # If a rate limit response (i.e. a response with status == 429) does not
 # include a `Retry-After` header, recommend pausing for this long.
 DEFAULT_RATE_LIMIT_DELAY = 60
-
-
-class Mode(Enum):
-    """
-    An enum describing the playback mode of a memento. When requesting a
-    memento (e.g. with :meth:`wayback.WaybackClient.get_memento`), you can use
-    these values to determine how the response body should be formatted.
-
-    For more details, see:
-    https://archive-access.sourceforge.net/projects/wayback/administrator_manual.html#Archival_URL_Replay_Mode
-
-    Examples
-    --------
-    >>> waybackClient.get_memento('https://noaa.gov/',
-    >>>                           timestamp=datetime.datetime(2018, 1, 2),
-    >>>                           mode=wayback.Mode.view)
-
-    **Values**
-
-    .. py:attribute:: original
-
-        Returns the HTTP response body as originally captured.
-
-    .. py:attribute:: view
-
-        Formats the response body so it can be viewed with a web
-        browser. URLs for links and subresources like scripts, stylesheets,
-        images, etc. will be modified to point to the equivalent memento in the
-        Wayback Machine so that the resulting page looks as similar as possible
-        to how it would have appeared when originally captured. It's mainly meant
-        for use with HTML pages. This is the playback mode you typically use when
-        browsing the Wayback Machine with a web browser.
-
-    .. py:attribute:: javascript
-
-        Formats the response body by updating URLs, similar
-        to ``Mode.view``, but designed for JavaScript instead of HTML.
-
-    .. py:attribute:: css
-
-        Formats the response body by updating URLs, similar to
-        ``Mode.view``, but designed for CSS instead of HTML.
-
-    .. py:attribute:: image
-
-        formats the response body similar to ``Mode.view``, but
-        designed for image files instead of HTML.
-    """
-    original = 'id_'
-    view = ''
-    javascript = 'js_'
-    css = 'cs_'
-    image = 'im_'
 
 
 def is_malformed_url(url):

--- a/src/wayback/_client.py
+++ b/src/wayback/_client.py
@@ -904,7 +904,7 @@ class WaybackClient(_utils.DepthCountedContext):
 
         if isinstance(url, CdxRecord):
             original_date = url.timestamp
-            original_url = url.url
+            original_url = url.original
         else:
             try:
                 original_url, original_date, mode = _utils.memento_url_data(url)

--- a/src/wayback/_client.py
+++ b/src/wayback/_client.py
@@ -821,7 +821,7 @@ class WaybackClient(_utils.DepthCountedContext):
                     # The CDX server returns 7 fields:
                     # urlkey, timestamp, original, mimetype, statuscode, digest, length
                     (urlkey, raw_timestamp, original, mimetype,
-                     raw_status, digest, raw_length) = text.split(' ')
+                     raw_status, digest, raw_length, *_) = text.split(' ')
 
                     statuscode = None if raw_status == '-' else int(raw_status)
                     length = None if raw_length == '-' else int(raw_length)

--- a/src/wayback/_models.py
+++ b/src/wayback/_models.py
@@ -1,77 +1,108 @@
-from collections import namedtuple
+from datetime import datetime
+from typing import NamedTuple, Optional
 from urllib.parse import urljoin
-from ._utils import CaseInsensitiveDict, memento_url_data
+from warnings import warn
+from ._utils import CaseInsensitiveDict, memento_url_data, format_memento_url
 
 
-CdxRecord = namedtuple('CdxRecord', (
-    # Raw CDX values
-    'key',
-    'timestamp',
-    'url',
-    'mime_type',
-    'status_code',
-    'digest',
-    'length',
-    # Synthesized values
-    'raw_url',
-    'view_url'
-))
-"""
-Item from iterable of results returned by :meth:`WaybackClient.search`
+class CdxRecord(NamedTuple):
+    """
+    Item from iterable of results returned by :meth:`WaybackClient.search`
 
-These attributes contain information provided directly by CDX.
+    These attributes contain information provided directly by CDX.
 
-.. py:attribute:: digest
+    .. py:attribute:: digest
 
-   Content hashed as a base 32 encoded SHA-1.
+       Content hashed as a base 32 encoded SHA-1.
 
-.. py:attribute:: key
+    .. py:attribute:: urlkey
 
-   SURT-formatted URL
+       SURT-formatted URL
 
-.. py:attribute:: length
+    .. py:attribute:: length
 
-   Size of captured content in bytes, such as :data:`2767`. This may be
-   inaccurate, and may even be :data:`None` instead of an integer. If the record is a
-   "revisit record", indicated by MIME type :data:`'warc/revisit'`, the length
-   seems to be the length of the reference, not the length of the content
-   itself. In other cases, the record has no length information at all, and
-   this attribute will be :data:`None` instead of a number.
+       Size of captured content in bytes, such as :data:`2767`. This may be
+       inaccurate, and may even be :data:`None` instead of an integer. If the record is a
+       "revisit record", indicated by MIME type :data:`'warc/revisit'`, the length
+       seems to be the length of the reference, not the length of the content
+       itself. In other cases, the record has no length information at all, and
+       this attribute will be :data:`None` instead of a number.
 
-.. py:attribute:: mime_type
+    .. py:attribute:: mimetype
 
-   MIME type of record, such as :data:`'text/html'`, :data:`'warc/revisit'` or
-   :data:`'unk'` ("unknown") if this information was not captured.
+       MIME type of record, such as :data:`'text/html'`, :data:`'warc/revisit'` or
+       :data:`'unk'` ("unknown") if this information was not captured.
 
-.. py:attribute:: status_code
+    .. py:attribute:: statuscode
 
-   Status code returned by the server when the record was captured, such as
-   :data:`200`. This is may be :data:`None` if the record is a revisit record.
+       Status code returned by the server when the record was captured, such as
+       :data:`200`. This is may be :data:`None` if the record is a revisit record.
 
-.. py:attribute:: timestamp
+    .. py:attribute:: timestamp
 
-   The capture time represented as a :class:`datetime.datetime`, such as
-   :data:`datetime.datetime(1996, 12, 31, 23, 58, 47, tzinfo=timezone.utc)`.
+       The capture time represented as a :class:`datetime.datetime`, such as
+       :data:`datetime.datetime(1996, 12, 31, 23, 58, 47, tzinfo=timezone.utc)`.
 
-.. py:attribute:: url
+    .. py:attribute:: original
 
-   The URL that was captured by this record, such as
-   :data:`'http://www.nasa.gov/'`.
+       The URL that was captured by this record, such as
+       :data:`'http://www.nasa.gov/'`.
 
-And these attributes are synthesized from the information provided by CDX.
+    And these attributes are synthesized from the information provided by CDX.
 
-.. py:attribute:: raw_url
+    .. py:attribute:: raw_url
 
-   The URL to the raw captured content, such as
-   :data:`'https://web.archive.org/web/19961231235847id_/http://www.nasa.gov/'`.
+       The URL to the raw captured content, such as
+       :data:`'https://web.archive.org/web/19961231235847id_/http://www.nasa.gov/'`.
 
-.. py:attribute:: view_url
+    .. py:attribute:: view_url
 
-   The URL to the public view on Wayback Machine. In this view, the links and
-   some subresources in the document are rewritten to point to Wayback URLs.
-   There is also a navigation panel around the content. Example URL:
-   :data:`'https://web.archive.org/web/19961231235847/http://www.nasa.gov/'`.
-"""
+       The URL to the public view on Wayback Machine. In this view, the links and
+       some subresources in the document are rewritten to point to Wayback URLs.
+       There is also a navigation panel around the content. Example URL:
+       :data:`'https://web.archive.org/web/19961231235847/http://www.nasa.gov/'`.
+    """
+    urlkey: str
+    timestamp: datetime
+    original: str
+    mimetype: str
+    statuscode: Optional[int]
+    digest: str
+    length: Optional[int]
+
+    @property
+    def key(self) -> str:
+        warn('The `key` attribute on `CdxRecord` was renamed to `urlkey`.',
+             DeprecationWarning, stacklevel=2)
+        return self.urlkey
+
+    @property
+    def url(self) -> str:
+        warn('The `url` attribute on `CdxRecord` was renamed to `original`.',
+             DeprecationWarning, stacklevel=2)
+        return self.original
+
+    @property
+    def mime_type(self) -> str:
+        warn('The `mime_type` attribute on `CdxRecord` was renamed to `mimetype`.',
+             DeprecationWarning, stacklevel=2)
+        return self.mimetype
+
+    @property
+    def status_code(self) -> Optional[int]:
+        warn('The `status_code` attribute on `CdxRecord` was renamed to `statuscode`.',
+             DeprecationWarning, stacklevel=2)
+        return self.statuscode
+
+    @property
+    def raw_url(self) -> str:
+        # 'id_' = Mode.original.value (hardcoded to avoid circular import with _client.py)
+        return format_memento_url(self.original, self.timestamp, mode='id_')
+
+    @property
+    def view_url(self) -> str:
+        # '' = Mode.view.value
+        return format_memento_url(self.original, self.timestamp, mode='')
 
 
 # NOTE: We use `py:attribute::` listings instead of the standard Numpy

--- a/src/wayback/_models.py
+++ b/src/wayback/_models.py
@@ -143,13 +143,11 @@ class CdxRecord(NamedTuple):
 
     @property
     def raw_url(self) -> str:
-        # 'id_' = Mode.original.value (hardcoded to avoid circular import with _client.py)
-        return format_memento_url(self.original, self.timestamp, mode='id_')
+        return format_memento_url(self.original, self.timestamp, mode=Mode.original.value)
 
     @property
     def view_url(self) -> str:
-        # '' = Mode.view.value
-        return format_memento_url(self.original, self.timestamp, mode='')
+        return format_memento_url(self.original, self.timestamp, mode=Mode.view.value)
 
 
 # NOTE: We use `py:attribute::` listings instead of the standard Numpy

--- a/src/wayback/_models.py
+++ b/src/wayback/_models.py
@@ -61,35 +61,53 @@ class Mode(Enum):
 
 class CdxRecord(NamedTuple):
     """
-    Item from iterable of results returned by :meth:`WaybackClient.search`
+    Represents an entry from Wayback's "CDX" index of mementos (archived HTTP
+    responses). These entries contain some metadata about the memento. You can
+    also pass a ``CdxRecord`` to :meth:`WaybackClient.get_memento` to
+    retrieve the corresponding memento.
 
-    These attributes contain information provided directly by CDX.
+    In general, you should not create new instances of ``CdxRecord`` yourself,
+    but should get them by calling :meth:`WaybackClient.search`.
 
-    Attributes
-    ----------
-    urlkey : str
-       SURT-formatted URL
+    **Attributes**
 
-    timestamp : datetime
+    .. py:attribute:: urlkey
+       :type: str
+
+       SURT-formatted URL.
+
+    .. py:attribute:: timestamp
+       :type: datetime
+
        The capture time represented as a :class:`datetime.datetime`, such as
        :data:`datetime.datetime(1996, 12, 31, 23, 58, 47, tzinfo=timezone.utc)`.
 
-    original : str
+    .. py:attribute:: original
+       :type: str
+
        The URL that was captured by this record, such as
        :data:`'http://www.nasa.gov/'`.
 
-    mimetype : str
+    .. py:attribute:: mimetype
+       :type: str
+
        MIME type of record, such as :data:`'text/html'`, :data:`'warc/revisit'` or
        :data:`'unk'` ("unknown") if this information was not captured.
 
-    statuscode : Optional[int]
+    .. py:attribute:: statuscode
+       :type: Optional[int]
+
        Status code returned by the server when the record was captured, such as
        :data:`200`. This is may be :data:`None` if the record is a revisit record.
 
-    digest : str
+    .. py:attribute:: digest
+       :type: str
+
        Content hashed as a base 32 encoded SHA-1.
 
-    length : Optional[int]
+    .. py:attribute:: length
+       :type: Optional[int]
+
        Size of captured content in bytes, such as :data:`2767`. This may be
        inaccurate, and may even be :data:`None` instead of an integer. If the record is a
        "revisit record", indicated by MIME type :data:`'warc/revisit'`, the length
@@ -97,17 +115,47 @@ class CdxRecord(NamedTuple):
        itself. In other cases, the record has no length information at all, and
        this attribute will be :data:`None` instead of a number.
 
-    And these attributes are synthesized from the information provided by CDX.
+    .. py:attribute:: raw_url
+       :type: str
 
-    raw_url : str
        The URL to the raw captured content, such as
        :data:`'https://web.archive.org/web/19961231235847id_/http://www.nasa.gov/'`.
 
-    view_url : str
+    .. py:attribute:: view_url
+       :type: str
+
        The URL to the public view on Wayback Machine. In this view, the links and
        some subresources in the document are rewritten to point to Wayback URLs.
        There is also a navigation panel around the content. Example URL:
        :data:`'https://web.archive.org/web/19961231235847/http://www.nasa.gov/'`.
+
+    .. py:attribute:: key
+       :type: str
+
+       .. deprecated:: 0.5.0
+          This attribute was renamed to :attr:`urlkey`. This name will be
+          removed in a future release.
+
+    .. py:attribute:: url
+       :type: str
+
+       .. deprecated:: 0.5.0
+          This attribute was renamed to :attr:`original`. This name will be
+          removed in a future release.
+
+    .. py:attribute:: mime_type
+       :type: str
+
+       .. deprecated:: 0.5.0
+          This attribute was renamed to :attr:`mimetype`. This name will be
+          removed in a future release.
+
+    .. py:attribute:: status_code
+       :type: str
+
+       .. deprecated:: 0.5.0
+          This attribute was renamed to :attr:`statuscode`. This name will be
+          removed in a future release.
     """
     urlkey: str
     timestamp: datetime

--- a/src/wayback/_models.py
+++ b/src/wayback/_models.py
@@ -11,16 +11,31 @@ class CdxRecord(NamedTuple):
 
     These attributes contain information provided directly by CDX.
 
-    .. py:attribute:: digest
-
-       Content hashed as a base 32 encoded SHA-1.
-
-    .. py:attribute:: urlkey
-
+    Attributes
+    ----------
+    urlkey : str
        SURT-formatted URL
 
-    .. py:attribute:: length
+    timestamp : datetime
+       The capture time represented as a :class:`datetime.datetime`, such as
+       :data:`datetime.datetime(1996, 12, 31, 23, 58, 47, tzinfo=timezone.utc)`.
 
+    original : str
+       The URL that was captured by this record, such as
+       :data:`'http://www.nasa.gov/'`.
+
+    mimetype : str
+       MIME type of record, such as :data:`'text/html'`, :data:`'warc/revisit'` or
+       :data:`'unk'` ("unknown") if this information was not captured.
+
+    statuscode : Optional[int]
+       Status code returned by the server when the record was captured, such as
+       :data:`200`. This is may be :data:`None` if the record is a revisit record.
+
+    digest : str
+       Content hashed as a base 32 encoded SHA-1.
+
+    length : Optional[int]
        Size of captured content in bytes, such as :data:`2767`. This may be
        inaccurate, and may even be :data:`None` instead of an integer. If the record is a
        "revisit record", indicated by MIME type :data:`'warc/revisit'`, the length
@@ -28,35 +43,13 @@ class CdxRecord(NamedTuple):
        itself. In other cases, the record has no length information at all, and
        this attribute will be :data:`None` instead of a number.
 
-    .. py:attribute:: mimetype
-
-       MIME type of record, such as :data:`'text/html'`, :data:`'warc/revisit'` or
-       :data:`'unk'` ("unknown") if this information was not captured.
-
-    .. py:attribute:: statuscode
-
-       Status code returned by the server when the record was captured, such as
-       :data:`200`. This is may be :data:`None` if the record is a revisit record.
-
-    .. py:attribute:: timestamp
-
-       The capture time represented as a :class:`datetime.datetime`, such as
-       :data:`datetime.datetime(1996, 12, 31, 23, 58, 47, tzinfo=timezone.utc)`.
-
-    .. py:attribute:: original
-
-       The URL that was captured by this record, such as
-       :data:`'http://www.nasa.gov/'`.
-
     And these attributes are synthesized from the information provided by CDX.
 
-    .. py:attribute:: raw_url
-
+    raw_url
        The URL to the raw captured content, such as
        :data:`'https://web.archive.org/web/19961231235847id_/http://www.nasa.gov/'`.
 
-    .. py:attribute:: view_url
-
+    view_url
        The URL to the public view on Wayback Machine. In this view, the links and
        some subresources in the document are rewritten to point to Wayback URLs.
        There is also a navigation panel around the content. Example URL:

--- a/src/wayback/_models.py
+++ b/src/wayback/_models.py
@@ -1,8 +1,62 @@
 from datetime import datetime
+from enum import Enum
 from typing import NamedTuple, Optional
 from urllib.parse import urljoin
 from warnings import warn
 from ._utils import CaseInsensitiveDict, memento_url_data, format_memento_url
+
+
+class Mode(Enum):
+    """
+    An enum describing the playback mode of a memento. When requesting a
+    memento (e.g. with :meth:`wayback.WaybackClient.get_memento`), you can use
+    these values to determine how the response body should be formatted.
+
+    For more details, see:
+    https://archive-access.sourceforge.net/projects/wayback/administrator_manual.html#Archival_URL_Replay_Mode
+
+    Examples
+    --------
+    >>> waybackClient.get_memento('https://noaa.gov/',
+    >>>                           timestamp=datetime.datetime(2018, 1, 2),
+    >>>                           mode=wayback.Mode.view)
+
+    **Values**
+
+    .. py:attribute:: original
+
+        Returns the HTTP response body as originally captured.
+
+    .. py:attribute:: view
+
+        Formats the response body so it can be viewed with a web
+        browser. URLs for links and subresources like scripts, stylesheets,
+        images, etc. will be modified to point to the equivalent memento in the
+        Wayback Machine so that the resulting page looks as similar as possible
+        to how it would have appeared when originally captured. It's mainly meant
+        for use with HTML pages. This is the playback mode you typically use when
+        browsing the Wayback Machine with a web browser.
+
+    .. py:attribute:: javascript
+
+        Formats the response body by updating URLs, similar
+        to ``Mode.view``, but designed for JavaScript instead of HTML.
+
+    .. py:attribute:: css
+
+        Formats the response body by updating URLs, similar to
+        ``Mode.view``, but designed for CSS instead of HTML.
+
+    .. py:attribute:: image
+
+        formats the response body similar to ``Mode.view``, but
+        designed for image files instead of HTML.
+    """
+    original = 'id_'
+    view = ''
+    javascript = 'js_'
+    css = 'cs_'
+    image = 'im_'
 
 
 class CdxRecord(NamedTuple):

--- a/src/wayback/_models.py
+++ b/src/wayback/_models.py
@@ -99,11 +99,11 @@ class CdxRecord(NamedTuple):
 
     And these attributes are synthesized from the information provided by CDX.
 
-    raw_url
+    raw_url : str
        The URL to the raw captured content, such as
        :data:`'https://web.archive.org/web/19961231235847id_/http://www.nasa.gov/'`.
 
-    view_url
+    view_url : str
        The URL to the public view on Wayback Machine. In this view, the links and
        some subresources in the document are rewritten to point to Wayback URLs.
        There is also a navigation panel around the content. Example URL:

--- a/src/wayback/tests/test_client.py
+++ b/src/wayback/tests/test_client.py
@@ -449,9 +449,7 @@ def test_get_memento_with_cdx_record():
                            '-',
                            200,
                            'abc',
-                           100,
-                           'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/',
-                           'https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/')
+                           100)
         memento = client.get_memento(record)
         assert 'https://www.fws.gov/birds/' == memento.url
         assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp

--- a/src/wayback/tests/test_client.py
+++ b/src/wayback/tests/test_client.py
@@ -153,7 +153,7 @@ def test_search_with_filter():
                                  from_date=date(2022, 1, 1),
                                  to_date=date(2022, 2, 1))
         versions = list(islice(versions, 10))
-        assert any((v.status_code == 200 for v in versions))
+        assert any((v.statuscode == 200 for v in versions))
 
         # Then an actually filtered request.
         versions = client.search('nasa.gov/',
@@ -163,7 +163,7 @@ def test_search_with_filter():
                                  to_date=date(2022, 2, 1),
                                  filter_field='statuscode:404')
         versions = list(islice(versions, 10))
-        assert all((v.status_code == 404 for v in versions))
+        assert all((v.statuscode == 404 for v in versions))
 
 
 @ia_vcr.use_cassette()
@@ -176,8 +176,8 @@ def test_search_with_filter_list():
                                  from_date=date(2022, 1, 1),
                                  to_date=date(2022, 2, 1))
         versions = list(islice(versions, 10))
-        assert any((v.status_code == 200 for v in versions))
-        assert any(('feature' not in v.url for v in versions))
+        assert any((v.statuscode == 200 for v in versions))
+        assert any(('feature' not in v.original for v in versions))
 
         # Then an actually filtered request.
         versions = client.search('nasa.gov/',
@@ -188,8 +188,8 @@ def test_search_with_filter_list():
                                  filter_field=['statuscode:404',
                                                'urlkey:.*feature.*'])
         versions = list(islice(versions, 10))
-        assert all((v.status_code == 404 for v in versions))
-        assert all(('feature' in v.url for v in versions))
+        assert all((v.statuscode == 404 for v in versions))
+        assert all(('feature' in v.original for v in versions))
 
 
 @ia_vcr.use_cassette()
@@ -204,8 +204,8 @@ def test_search_with_filter_tuple():
                                  filter_field=('statuscode:404',
                                                'urlkey:.*feature.*'))
         versions = list(islice(versions, 10))
-        assert all((v.status_code == 404 for v in versions))
-        assert all(('feature' in v.url for v in versions))
+        assert all((v.statuscode == 404 for v in versions))
+        assert all(('feature' in v.original for v in versions))
 
 
 def test_search_removes_malformed_entries(requests_mock):

--- a/src/wayback/tests/test_client.py
+++ b/src/wayback/tests/test_client.py
@@ -7,9 +7,9 @@ import requests
 from unittest import mock
 from .support import create_vcr
 from .._utils import SessionClosedError
-from .._client import (CdxRecord,
-                       Mode,
-                       WaybackSession,
+from .._models import (CdxRecord,
+                       Mode)
+from .._client import (WaybackSession,
                        WaybackClient)
 from ..exceptions import (BlockedSiteError,
                           MementoPlaybackError,

--- a/src/wayback/tests/test_client.py
+++ b/src/wayback/tests/test_client.py
@@ -295,11 +295,18 @@ def test_search_handles_bad_timestamp_cdx_records(requests_mock):
 
 
 def test_search_parses_all_fields(requests_mock):
-    cdx_data = (
-        "com,cnn)/ 20100215131836 http://www.cnn.com/ "
-        "text/html 200 T6CDCO73TS77BY67HLKYFLHKT2APUM5Y 24186 "
-        "extra ignored fields"
-    )
+    cdx_data = ' '.join([
+        'com,cnn)/',
+        '20100215131836',
+        'http://www.cnn.com/',
+        'text/html',
+        '200',
+        'T6CDCO73TS77BY67HLKYFLHKT2APUM5Y',
+        '24186',
+        'extra',
+        'ignored',
+        'fields',
+    ])
     with WaybackClient() as client:
         requests_mock.get('https://web.archive.org/cdx/search/cdx'
                           '?url=http%3A%2F%2Fcnn.com'

--- a/src/wayback/tests/test_client.py
+++ b/src/wayback/tests/test_client.py
@@ -294,6 +294,28 @@ def test_search_handles_bad_timestamp_cdx_records(requests_mock):
         assert record_list[4].timestamp.day == 24
 
 
+def test_search_parses_all_fields(requests_mock):
+    cdx_data = (
+        "com,cnn)/ 20100215131836 http://www.cnn.com/ "
+        "text/html 200 T6CDCO73TS77BY67HLKYFLHKT2APUM5Y 24186 "
+        "extra ignored fields"
+    )
+    with WaybackClient() as client:
+        requests_mock.get('https://web.archive.org/cdx/search/cdx'
+                          '?url=http%3A%2F%2Fcnn.com'
+                          '&showResumeKey=true&resolveRevisits=true',
+                          [{'status_code': 200, 'text': cdx_data}])
+        record = next(client.search('http://cnn.com'))
+
+        assert record.urlkey == 'com,cnn)/'
+        assert record.timestamp == datetime(2010, 2, 15, 13, 18, 36, tzinfo=timezone.utc)
+        assert record.original == 'http://www.cnn.com/'
+        assert record.mimetype == 'text/html'
+        assert record.statuscode == 200
+        assert record.digest == 'T6CDCO73TS77BY67HLKYFLHKT2APUM5Y'
+        assert record.length == 24186
+
+
 @ia_vcr.use_cassette()
 def test_get_memento():
     with WaybackClient() as client:

--- a/src/wayback/tests/test_models.py
+++ b/src/wayback/tests/test_models.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timezone
+from .._models import CdxRecord
+import pytest
+
+
+def test_cdx_record_urls():
+    record = CdxRecord(
+        urlkey='org,nasa)/',
+        timestamp=datetime(1996, 12, 31, 23, 58, 47, tzinfo=timezone.utc),
+        original='http://www.nasa.gov/',
+        mimetype='text/html',
+        statuscode=200,
+        digest='ABC',
+        length=100
+    )
+
+    # raw_url should have 'id_' mode
+    expected_raw = 'https://web.archive.org/web/19961231235847id_/http://www.nasa.gov/'
+    assert record.raw_url == expected_raw
+
+    # view_url should have no mode suffix
+    expected_view = 'https://web.archive.org/web/19961231235847/http://www.nasa.gov/'
+    assert record.view_url == expected_view
+
+
+def test_cdx_record_deprecated_fields():
+    record = CdxRecord(
+        urlkey='org,nasa)/',
+        timestamp=datetime(1996, 12, 31, 23, 58, 47, tzinfo=timezone.utc),
+        original='http://www.nasa.gov/',
+        mimetype='text/html',
+        statuscode=200,
+        digest='ABC',
+        length=100
+    )
+
+    with pytest.warns(DeprecationWarning, match='key'):
+        assert record.key == 'org,nasa)/'
+    with pytest.warns(DeprecationWarning, match='url'):
+        assert record.url == 'http://www.nasa.gov/'
+    with pytest.warns(DeprecationWarning, match='mime_type'):
+        assert record.mime_type == 'text/html'
+    with pytest.warns(DeprecationWarning, match='status_code'):
+        assert record.status_code == 200

--- a/src/wayback/tests/test_models.py
+++ b/src/wayback/tests/test_models.py
@@ -14,13 +14,8 @@ def test_cdx_record_urls():
         length=100
     )
 
-    # raw_url should have 'id_' mode
-    expected_raw = 'https://web.archive.org/web/19961231235847id_/http://www.nasa.gov/'
-    assert record.raw_url == expected_raw
-
-    # view_url should have no mode suffix
-    expected_view = 'https://web.archive.org/web/19961231235847/http://www.nasa.gov/'
-    assert record.view_url == expected_view
+    assert record.raw_url == 'https://web.archive.org/web/19961231235847id_/http://www.nasa.gov/'
+    assert record.view_url == 'https://web.archive.org/web/19961231235847/http://www.nasa.gov/'
 
 
 def test_cdx_record_deprecated_fields():


### PR DESCRIPTION
Rename CdxRecord attributes to match the field names used by the CDX
server:
```
  key          -> urlkey
  url          -> original
  mime_type    -> mimetype
  status_code  -> statuscode
```

## Changes

- `CdxRecord` migrated from `collections.namedtuple` to
  `typing.NamedTuple` so the class can host the deprecation properties
  (and gets proper type hints for free).
- `raw_url` and `view_url` are now computed `@property`s derived from
  `original` and `timestamp`, per  #130.
- `_client.py` simplified — `search()` no longer does the
  `CdxRecord(*split, '', '')` + `_replace(...)` dance; it now just
  unpacks the 7 CDX fields and constructs the record in one step.
- The docstring moved inside the class body (it was a floating
  module-level string before).