### PR TITLE
Clarify CDX record `digest` and `length` docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019-2023, Environmental Data Governance Initiative (EDGI)
+Copyright (c) 2019-2026, Environmental Data Governance Initiative (EDGI)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,6 @@ Thanks to the following people for their contributions and help on this package!
 License & Copyright
 -------------------
 
-Copyright (C) 2019-2023 Environmental Data and Governance Initiative (EDGI)
+Copyright (C) 2019-2026 Environmental Data and Governance Initiative (EDGI)
 
 This program is free software: you can redistribute it and/or modify it under the terms of the 3-Clause BSD License. See the `LICENSE <https://github.com/edgi-govdata-archiving/wayback/blob/master/LICENSE>`_ file for details.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,7 +66,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'wayback'
-copyright = '2019–2023, Environmental Data & Governance Initiative'
+copyright = '2019–2026, Environmental Data & Governance Initiative'
 author = 'Environmental Data & Governance Initiative'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/src/wayback/_models.py
+++ b/src/wayback/_models.py
@@ -103,17 +103,33 @@ class CdxRecord(NamedTuple):
     .. py:attribute:: digest
        :type: str
 
-       Content hashed as a base 32 encoded SHA-1.
+       The base 32-encoded SHA-1 hash of the archived HTTP response body. This
+       can be useful for comparing to other ``CdxRecord`` instances or avoiding
+       duplicate requests for mementos.
+
+       Please keep in mind that this digest is generally computed based on the
+       response body *as stored on disk* (usually the exact bytes originally
+       received when saving the response), so is not useful for validation
+       or fixity checks against a memento loaded with
+       :meth:`WaybackClient.get_memento`. For example, if the response body was
+       stored in brotli-compressed form but *transferred to you* in
+       gzip-compressed form, your bytes will not match this digest.
+
+       For revisit records, this is the digest of the originally received HTTP
+       response body as it *would have been stored*, so you can use it to match
+       a non-revisit record containing the same response body. (But keep in
+       mind this is just the body. It does not include HTTP headers, which may
+       have been different for two records with the same digest.)
 
     .. py:attribute:: length
        :type: Optional[int]
 
-       Size of captured content in bytes, such as :data:`2767`. This may be
-       inaccurate, and may even be :data:`None` instead of an integer. If the record is a
-       "revisit record", indicated by MIME type :data:`'warc/revisit'`, the length
-       seems to be the length of the reference, not the length of the content
-       itself. In other cases, the record has no length information at all, and
-       this attribute will be :data:`None` instead of a number.
+       Size (in bytes) of the archived data *as stored on disk*. Like
+       :attr:`digest`, this usually will not be useful for external users,
+       since it does not reflect the actual archived HTTP response body size.
+       For example, revisit records will generally be small because the
+       archived data on disk is just a pointer to a different record that was
+       saved previously.
 
     .. py:attribute:: raw_url
        :type: str


### PR DESCRIPTION
The `digest` and `length` fields in CDX search results might not be what a lot of users expect them to be, and this updates the docs to be clearer about what they do and don't actually represent. (I certainly didn’t understand them when I first built this package, but have learned a lot about these systems in the years since then.)

In particular, `digest` cannot be used for fixity checks of what you receive through the memento API (it refers to specifically what bytes are stored in the underlying WARC on Wayback servers). `length` is similar, and is generally not useful unless you have access to the WARC data the record is referring to.

This also updates copyright dates, since I noticed they were way out of date when working on this.