### PR TITLE
Upgrade Sphinx to v9.1 and iPython to v9.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ dev = [
 # versions < 3.10 (which we support), so you have to install them in a separate
 # environment from the other dev dependencies.
 docs = [
-    "sphinx ~=8.2",
-    "ipython ~=8.37.0",
+    "sphinx ~=9.1.0",
+    "ipython ~=9.13.0",
     "numpydoc ~=1.10.0",
     "sphinx-copybutton ~=0.5.2",
     "sphinx_rtd_theme >=3.0.2,<3.2.0",


### PR DESCRIPTION
This updates Sphinx and iPython to their current releases, which fixes a number of warnings and build issues.