### PR TITLE
Give Memento class a nicer repr

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -58,6 +58,8 @@ Fixes & Maintenance
 
 - The default rate limits have been further tweaked since v0.4.4 based on closer collaboration with Internet Archive staff. Rate limits are also now more accurately applied to each individual request (they were previously applied more roughly, without respect to retries and redirects).
 
+- :class:`wayback.Memento` now has a nicer, more informative ``repr`` when you are using a notebook or Python REPL. (:issue:`192`)
+
 
 v0.4.5 (2024-02-01)
 -------------------

--- a/src/wayback/_models.py
+++ b/src/wayback/_models.py
@@ -434,6 +434,11 @@ class Memento:
     def __exit__(self, *_args):
         self.close()
 
+    def __repr__(self):
+        return (f'<{type(self).__module__.rsplit(".", 1)[0]}'
+                f'.{type(self).__name__} url="{self.url}" '
+                f'timestamp="{self.timestamp.isoformat()}">')
+
     @classmethod
     def parse_memento_headers(cls, raw_headers, url='https://web.archive.org/'):
         """

--- a/src/wayback/_models.py
+++ b/src/wayback/_models.py
@@ -435,7 +435,7 @@ class Memento:
         self.close()
 
     def __repr__(self):
-        return (f'<{type(self).__module__.rsplit(".", 1)[0]}'
+        return (f'<{type(self).__module__.split("._", 1)[0]}'
                 f'.{type(self).__name__} url="{self.url}" '
                 f'timestamp="{self.timestamp.isoformat()}">')
 

--- a/src/wayback/tests/test_models.py
+++ b/src/wayback/tests/test_models.py
@@ -54,5 +54,4 @@ def test_memento_repr():
         history=[],
         debug_history=[]
     )
-    print(repr(memento))
     assert repr(memento) == '<wayback.Memento url="https://www3.epa.gov/" timestamp="2022-10-01T00:00:00+00:00">'

--- a/src/wayback/tests/test_models.py
+++ b/src/wayback/tests/test_models.py
@@ -54,4 +54,5 @@ def test_memento_repr():
         history=[],
         debug_history=[]
     )
-    assert repr(memento) == '<wayback.Memento url="https://www3.epa.gov/" timestamp="2022-10-01T00:00:00Z">'
+    print(repr(memento))
+    assert repr(memento) == '<wayback.Memento url="https://www3.epa.gov/" timestamp="2022-10-01T00:00:00+00:00">'

--- a/src/wayback/tests/test_models.py
+++ b/src/wayback/tests/test_models.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from .._models import CdxRecord
+from .._models import CdxRecord, Memento
 import pytest
 
 
@@ -37,3 +37,21 @@ def test_cdx_record_deprecated_fields():
         assert record.mime_type == 'text/html'
     with pytest.warns(DeprecationWarning, match='status_code'):
         assert record.status_code == 200
+
+
+def test_memento_repr():
+    memento = Memento(
+        url='https://www3.epa.gov/',
+        timestamp=datetime(2022, 10, 1, 0, 0, 0, tzinfo=timezone.utc),
+        mode='id_',
+        memento_url='https://web.archive.org/web/20221001000000id_/https://www3.epa.gov/',
+        status_code=200,
+        headers={},
+        encoding='utf-8',
+        raw=None,
+        raw_headers={},
+        links={},
+        history=[],
+        debug_history=[]
+    )
+    assert repr(memento) == '<wayback.Memento url="https://www3.epa.gov/" timestamp="2022-10-01T00:00:00Z">'


### PR DESCRIPTION
Simple changes for #105, nicer `__repr__` for Memento Class

Example:
```py
from datetime import datetime, timezone
from wayback._models import Memento, Mode                                                   
m = Memento(
    url='https://www3.epa.gov/',
    timestamp=datetime(2022, 10, 1, 0, 0, 0, tzinfo=timezone.utc),
    mode='id_',
    memento_url='https://web.archive.org/web/20221001000000id_/https://www3.epa.gov/',
    status_code=200,
    headers={},
    encoding='utf-8',
    raw=None,
    raw_headers={},
    links={},
    history=[],
    debug_history=[]
)
repr(m)
```

Outputs:
`'<wayback.Memento url="https://www3.epa.gov/" timestamp="2022-10-01T00:00:00+00:00">'`