### PR TITLE
Add support for `datetime.timedelta` to `get_memento()`

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -5,9 +5,6 @@ Release History
 (In Development)
 ----------------
 
-- Updated license identifier to follow PEP 639 style. This should make sure the license is surfaced better and more clearly on PyPI. (:issue:`186`)
-
-
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
@@ -52,13 +49,24 @@ Features
   - ``mime_type`` (now ``mimetype``).
   - ``status_code`` (now ``statuscode``).
 
+- You can now use a :class:`datetime.timedelta` instance for the ``target_window`` argument to :meth:`wayback.WaybackClient.get_memento` (an integer indicating a number of seconds still works, too). (:issue:`193`)
+
 
 Fixes & Maintenance
 ^^^^^^^^^^^^^^^^^^^
 
 - The default rate limits have been further tweaked since v0.4.4 based on closer collaboration with Internet Archive staff. Rate limits are also now more accurately applied to each individual request (they were previously applied more roughly, without respect to retries and redirects).
 
+- Updated license identifier to follow PEP 639 style. This should make sure the license is surfaced better and more clearly on PyPI. (:issue:`186`)
+
 - :class:`wayback.Memento` now has a nicer, more informative ``repr`` when you are using a notebook or Python REPL. (:issue:`192`)
+
+
+New Contributors
+^^^^^^^^^^^^^^^^
+
+- `Derzan Chiang <https://github.com/MiTo0o>`_ (Code, Tests, Documentation)
+- `Beckett Frey <https://github.com/BeckettFrey>`_ (Code, Tests, Documentation)
 
 
 v0.4.5 (2024-02-01)

--- a/src/wayback/_client.py
+++ b/src/wayback/_client.py
@@ -855,10 +855,10 @@ class WaybackClient(_utils.DepthCountedContext):
             within ``target_window``. If unset, this will be the same as
             ``exact``.
         target_window : int or datetime.timedelta, default: 86400
-            If the memento is of a redirect, allow up to this many seconds
-            between the capture of the redirect and the capture of the
-            redirect's target URL. This window also applies to the first
-            memento if ``exact=False`` and the originally
+            If the memento is of a redirect, allow up to this amount of time
+            (in seconds if an integer) between the capture of the redirect
+            and the capture of the redirect's target URL. This window also 
+            applies to the first memento if ``exact=False`` and the originally
             requested memento was not available.
             Defaults to 86,400 (24 hours).
         follow_redirects : boolean, default: True

--- a/src/wayback/_client.py
+++ b/src/wayback/_client.py
@@ -857,7 +857,7 @@ class WaybackClient(_utils.DepthCountedContext):
         target_window : int or datetime.timedelta, default: 86400
             If the memento is of a redirect, allow up to this amount of time
             (in seconds if an integer) between the capture of the redirect
-            and the capture of the redirect's target URL. This window also 
+            and the capture of the redirect's target URL. This window also
             applies to the first memento if ``exact=False`` and the originally
             requested memento was not available.
             Defaults to 86,400 (24 hours).

--- a/src/wayback/_client.py
+++ b/src/wayback/_client.py
@@ -804,7 +804,7 @@ class WaybackClient(_utils.DepthCountedContext):
 
     def get_memento(self, url, timestamp=None, mode=Mode.original, *,
                     exact=True, exact_redirects=None,
-                    target_window=24 * 60 * 60, follow_redirects=True,
+                    target_window=timedelta(days=1), follow_redirects=True,
                     # Deprecated Parameters
                     datetime=None):
         """

--- a/src/wayback/_client.py
+++ b/src/wayback/_client.py
@@ -14,7 +14,7 @@ Other potentially useful links:
 """
 
 from base64 import b32encode
-from datetime import date
+from datetime import date, timedelta
 import hashlib
 import logging
 import re
@@ -854,7 +854,7 @@ class WaybackClient(_utils.DepthCountedContext):
             closest-in-time memento to the intended target, so long as it is
             within ``target_window``. If unset, this will be the same as
             ``exact``.
-        target_window : int, default: 86400
+        target_window : int or datetime.timedelta, default: 86400
             If the memento is of a redirect, allow up to this many seconds
             between the capture of the redirect and the capture of the
             redirect's target URL. This window also applies to the first
@@ -884,6 +884,9 @@ class WaybackClient(_utils.DepthCountedContext):
                  DeprecationWarning,
                  stacklevel=2)
             timestamp = timestamp or datetime
+
+        if isinstance(target_window, timedelta):
+            target_window = target_window.total_seconds()
 
         if exact_redirects is None:
             exact_redirects = exact

--- a/src/wayback/_client.py
+++ b/src/wayback/_client.py
@@ -804,7 +804,7 @@ class WaybackClient(_utils.DepthCountedContext):
 
     def get_memento(self, url, timestamp=None, mode=Mode.original, *,
                     exact=True, exact_redirects=None,
-                    target_window=timedelta(days=1), follow_redirects=True,
+                    target_window=timedelta(hours=24), follow_redirects=True,
                     # Deprecated Parameters
                     datetime=None):
         """

--- a/src/wayback/tests/test_client.py
+++ b/src/wayback/tests/test_client.py
@@ -539,6 +539,16 @@ def test_get_memento_target_window():
         assert memento.timestamp == datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc)
 
 
+@ia_vcr.use_cassette('test_get_memento_target_window.yaml')
+def test_get_memento_timedelta_target_window():
+    with WaybackClient() as client:
+        memento = client.get_memento('https://www.fws.gov/birds/',
+                                     date(2017, 11, 1),
+                                     exact=False,
+                                     target_window=timedelta(days=25))
+        assert memento.timestamp == datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc)
+
+
 @ia_vcr.use_cassette()
 def test_get_memento_raises_when_memento_is_outside_target_window():
     with pytest.raises(MementoPlaybackError):


### PR DESCRIPTION
I'm assuming you wanted to support both seconds and timedelta per #55?