### PR TITLE
test: disable rate limiting in tests using shared test_client fixture

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,7 @@ Contributors
 
 Thanks to the following people for their contributions and help on this package! See our `contributing guidelines <https://github.com/edgi-govdata-archiving/wayback/blob/main/CONTRIBUTING.rst>`_ to find out how you can help.
 
+- `@Adeelp1 <https://github.com/Adeelp1>`_ (Tests)
 - `Dan Allan <https://github.com/danielballan>`_ (Code, Tests, Documentation, Reviews)
 - `Rob Brackett <https://github.com/Mr0grog>`_ (Code, Tests, Documentation, Reviews)
 - `Derzan Chiang <https://github.com/MiTo0o>`_ (Code, Tests, Documentation)

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -61,12 +61,15 @@ Fixes & Maintenance
 
 - :class:`wayback.Memento` now has a nicer, more informative ``repr`` when you are using a notebook or Python REPL. (:issue:`192`)
 
+- Tests where rate limits don’t matter now run faster. (:issue:`194`)
+
 
 New Contributors
 ^^^^^^^^^^^^^^^^
 
-- `Derzan Chiang <https://github.com/MiTo0o>`_ (Code, Tests, Documentation)
-- `Beckett Frey <https://github.com/BeckettFrey>`_ (Code, Tests, Documentation)
+- `Derzan Chiang <https://github.com/MiTo0o>`_
+- `Beckett Frey <https://github.com/BeckettFrey>`_
+- `@Adeelp1 <https://github.com/Adeelp1>`_
 
 
 v0.4.5 (2024-02-01)

--- a/src/wayback/tests/conftest.py
+++ b/src/wayback/tests/conftest.py
@@ -2,6 +2,7 @@ import pytest
 from wayback import WaybackClient, WaybackSession
 from wayback._utils import RateLimit
 
+
 @pytest.fixture
 def test_client():
     session = WaybackSession(

--- a/src/wayback/tests/conftest.py
+++ b/src/wayback/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+from wayback import WaybackClient, WaybackSession
+from wayback._utils import RateLimit
+
+@pytest.fixture
+def test_client():
+    session = WaybackSession(
+        search_calls_per_second=RateLimit(0),
+        memento_calls_per_second=RateLimit(0),
+        timemap_calls_per_second=RateLimit(0)
+    )
+    client = WaybackClient(session)
+    yield client
+    client.close()

--- a/src/wayback/tests/test_client.py
+++ b/src/wayback/tests/test_client.py
@@ -52,62 +52,58 @@ def get_file(filepath):
 
 
 @ia_vcr.use_cassette()
-def test_search():
-    with WaybackClient() as client:
-        versions = client.search('nasa.gov',
-                                 from_date=datetime(1996, 10, 1),
-                                 to_date=datetime(1997, 2, 1))
-        for v in versions:
-            assert v.timestamp >= datetime(1996, 10, 1, tzinfo=timezone.utc)
-            assert v.timestamp <= datetime(1997, 2, 1, tzinfo=timezone.utc)
+def test_search(test_client):
+    versions = test_client.search('nasa.gov',
+                                  from_date=datetime(1996, 10, 1),
+                                  to_date=datetime(1997, 2, 1))
+    for v in versions:
+        assert v.timestamp >= datetime(1996, 10, 1, tzinfo=timezone.utc)
+        assert v.timestamp <= datetime(1997, 2, 1, tzinfo=timezone.utc)
 
 
 @ia_vcr.use_cassette()
-def test_search_with_date():
-    with WaybackClient() as client:
-        versions = client.search('dw.com',
-                                 from_date=date(2019, 10, 1),
-                                 to_date=date(2020, 3, 1))
-        for v in versions:
-            assert v.timestamp >= datetime(2019, 10, 1, tzinfo=timezone.utc)
-            assert v.timestamp <= datetime(2020, 3, 1, tzinfo=timezone.utc)
+def test_search_with_date(test_client):
+    versions = test_client.search('dw.com',
+                                  from_date=date(2019, 10, 1),
+                                  to_date=date(2020, 3, 1))
+    for v in versions:
+        assert v.timestamp >= datetime(2019, 10, 1, tzinfo=timezone.utc)
+        assert v.timestamp <= datetime(2020, 3, 1, tzinfo=timezone.utc)
 
 
 @ia_vcr.use_cassette()
-def test_search_with_timezone():
-    with WaybackClient() as client:
-        # Search using UTC, equivalent to the test above where we provide a
-        # datetime with no timezone.
-        tzinfo = timezone(timedelta(hours=0))
-        t0 = datetime(1996, 12, 31, 23, 58, 47, tzinfo=tzinfo)
-        versions = client.search('nasa.gov',
-                                 from_date=t0)
-        version = next(versions)
-        assert version.timestamp == datetime(1996, 12, 31, 23, 58, 47,
-                                             tzinfo=timezone.utc)
+def test_search_with_timezone(test_client):
+    # Search using UTC, equivalent to the test above where we provide a
+    # datetime with no timezone.
+    tzinfo = timezone(timedelta(hours=0))
+    t0 = datetime(1996, 12, 31, 23, 58, 47, tzinfo=tzinfo)
+    versions = test_client.search('nasa.gov',
+                                  from_date=t0)
+    version = next(versions)
+    assert version.timestamp == datetime(1996, 12, 31, 23, 58, 47,
+                                         tzinfo=timezone.utc)
 
-        # Search using UTC - 5, equivalent to (1997, 1, 1, 4, ...) in UTC
-        # so that we miss the result above and expect a different, later one.
-        tzinfo = timezone(timedelta(hours=-5))
-        t0 = datetime(1996, 12, 31, 23, 58, 47, tzinfo=tzinfo)
-        versions = client.search('nasa.gov',
-                                 from_date=t0)
-        version = next(versions)
-        assert version.timestamp == datetime(1997, 6, 5, 23, 5, 59,
-                                             tzinfo=timezone.utc)
+    # Search using UTC - 5, equivalent to (1997, 1, 1, 4, ...) in UTC
+    # so that we miss the result above and expect a different, later one.
+    tzinfo = timezone(timedelta(hours=-5))
+    t0 = datetime(1996, 12, 31, 23, 58, 47, tzinfo=tzinfo)
+    versions = test_client.search('nasa.gov',
+                                  from_date=t0)
+    version = next(versions)
+    assert version.timestamp == datetime(1997, 6, 5, 23, 5, 59,
+                                         tzinfo=timezone.utc)
 
 
 @ia_vcr.use_cassette()
-def test_search_multipage():
+def test_search_multipage(test_client):
     # Set page size limits low enough to guarantee multiple pages
-    with WaybackClient() as client:
-        versions = client.search('cnn.com',
-                                 from_date=datetime(2001, 4, 10),
-                                 to_date=datetime(2001, 5, 10),
-                                 limit=25)
+    versions = test_client.search('cnn.com',
+                                  from_date=datetime(2001, 4, 10),
+                                  to_date=datetime(2001, 5, 10),
+                                  limit=25)
 
-        # Exhaust the generator and make sure no entries trigger errors.
-        list(versions)
+    # Exhaust the generator and make sure no entries trigger errors.
+    list(versions)
 
 
 @ia_vcr.use_cassette()
@@ -122,93 +118,88 @@ def test_search_cannot_iterate_after_session_closing():
 
 
 @ia_vcr.use_cassette()
-def test_search_does_not_repeat_results():
-    with WaybackClient() as client:
-        versions = client.search('energystar.gov/',
-                                 from_date=datetime(2020, 6, 12),
-                                 to_date=datetime(2020, 6, 13))
-        previous = None
-        for version in versions:
-            assert version != previous
-            previous = version
+def test_search_does_not_repeat_results(test_client):
+    versions = test_client.search('energystar.gov/',
+                                  from_date=datetime(2020, 6, 12),
+                                  to_date=datetime(2020, 6, 13))
+    previous = None
+    for version in versions:
+        assert version != previous
+        previous = version
 
 
 @ia_vcr.use_cassette()
-def test_search_raises_for_blocked_urls():
+def test_search_raises_for_blocked_urls(test_client):
     with pytest.raises(BlockedSiteError):
-        with WaybackClient() as client:
-            versions = client.search('https://nationalpost.com/health',
-                                     from_date=datetime(2019, 10, 1),
-                                     to_date=datetime(2019, 10, 2))
-            next(versions)
+        versions = test_client.search('https://nationalpost.com/health',
+                                      from_date=datetime(2019, 10, 1),
+                                      to_date=datetime(2019, 10, 2))
+        next(versions)
 
 
 @ia_vcr.use_cassette()
-def test_search_with_filter():
-    with WaybackClient() as client:
-        # Check an unfiltered request to cover false positives.
-        versions = client.search('nasa.gov/',
-                                 match_type='prefix',
-                                 limit=10,
-                                 from_date=date(2022, 1, 1),
-                                 to_date=date(2022, 2, 1))
-        versions = list(islice(versions, 10))
-        assert any((v.statuscode == 200 for v in versions))
+def test_search_with_filter(test_client):
+    # Check an unfiltered request to cover false positives.
+    versions = test_client.search('nasa.gov/',
+                                  match_type='prefix',
+                                  limit=10,
+                                  from_date=date(2022, 1, 1),
+                                  to_date=date(2022, 2, 1))
+    versions = list(islice(versions, 10))
+    assert any((v.statuscode == 200 for v in versions))
 
-        # Then an actually filtered request.
-        versions = client.search('nasa.gov/',
-                                 match_type='prefix',
-                                 limit=10,
-                                 from_date=date(2022, 1, 1),
-                                 to_date=date(2022, 2, 1),
-                                 filter_field='statuscode:404')
-        versions = list(islice(versions, 10))
-        assert all((v.statuscode == 404 for v in versions))
-
-
-@ia_vcr.use_cassette()
-def test_search_with_filter_list():
-    with WaybackClient() as client:
-        # Check an unfiltered request to cover false positives.
-        versions = client.search('nasa.gov/',
-                                 match_type='prefix',
-                                 limit=10,
-                                 from_date=date(2022, 1, 1),
-                                 to_date=date(2022, 2, 1))
-        versions = list(islice(versions, 10))
-        assert any((v.statuscode == 200 for v in versions))
-        assert any(('feature' not in v.original for v in versions))
-
-        # Then an actually filtered request.
-        versions = client.search('nasa.gov/',
-                                 match_type='prefix',
-                                 limit=10,
-                                 from_date=date(2022, 1, 1),
-                                 to_date=date(2022, 2, 1),
-                                 filter_field=['statuscode:404',
-                                               'urlkey:.*feature.*'])
-        versions = list(islice(versions, 10))
-        assert all((v.statuscode == 404 for v in versions))
-        assert all(('feature' in v.original for v in versions))
+    # Then an actually filtered request.
+    versions = test_client.search('nasa.gov/',
+                                  match_type='prefix',
+                                  limit=10,
+                                  from_date=date(2022, 1, 1),
+                                  to_date=date(2022, 2, 1),
+                                  filter_field='statuscode:404')
+    versions = list(islice(versions, 10))
+    assert all((v.statuscode == 404 for v in versions))
 
 
 @ia_vcr.use_cassette()
-def test_search_with_filter_tuple():
-    with WaybackClient() as client:
-        # Then an actually filtered request.
-        versions = client.search('nasa.gov/',
-                                 match_type='prefix',
-                                 limit=10,
-                                 from_date=date(2022, 1, 1),
-                                 to_date=date(2022, 2, 1),
-                                 filter_field=('statuscode:404',
-                                               'urlkey:.*feature.*'))
-        versions = list(islice(versions, 10))
-        assert all((v.statuscode == 404 for v in versions))
-        assert all(('feature' in v.original for v in versions))
+def test_search_with_filter_list(test_client):
+    # Check an unfiltered request to cover false positives.
+    versions = test_client.search('nasa.gov/',
+                                  match_type='prefix',
+                                  limit=10,
+                                  from_date=date(2022, 1, 1),
+                                  to_date=date(2022, 2, 1))
+    versions = list(islice(versions, 10))
+    assert any((v.statuscode == 200 for v in versions))
+    assert any(('feature' not in v.original for v in versions))
+
+    # Then an actually filtered request.
+    versions = test_client.search('nasa.gov/',
+                                  match_type='prefix',
+                                  limit=10,
+                                  from_date=date(2022, 1, 1),
+                                  to_date=date(2022, 2, 1),
+                                  filter_field=['statuscode:404',
+                                                'urlkey:.*feature.*'])
+    versions = list(islice(versions, 10))
+    assert all((v.statuscode == 404 for v in versions))
+    assert all(('feature' in v.original for v in versions))
 
 
-def test_search_removes_malformed_entries(requests_mock):
+@ia_vcr.use_cassette()
+def test_search_with_filter_tuple(test_client):
+    # Then an actually filtered request.
+    versions = test_client.search('nasa.gov/',
+                                  match_type='prefix',
+                                  limit=10,
+                                  from_date=date(2022, 1, 1),
+                                  to_date=date(2022, 2, 1),
+                                  filter_field=('statuscode:404',
+                                                'urlkey:.*feature.*'))
+    versions = list(islice(versions, 10))
+    assert all((v.statuscode == 404 for v in versions))
+    assert all(('feature' in v.original for v in versions))
+
+
+def test_search_removes_malformed_entries(test_client, requests_mock):
     """
     The CDX index contains many lines for things that can't actually be
     archived and will have no corresponding memento, like `mailto:` and `data:`
@@ -222,20 +213,19 @@ def test_search_removes_malformed_entries(requests_mock):
     with open(Path(__file__).parent / 'test_files' / 'malformed_cdx.txt') as f:
         bad_cdx_data = f.read()
 
-    with WaybackClient() as client:
-        requests_mock.get('https://web.archive.org/cdx/search/cdx'
-                          '?url=https%3A%2F%2Fepa.gov%2F%2A'
-                          '&from=20200418000000&to=20200419000000'
-                          '&showResumeKey=true&resolveRevisits=true',
-                          [{'status_code': 200, 'text': bad_cdx_data}])
-        records = client.search('https://epa.gov/*',
-                                from_date=datetime(2020, 4, 18),
-                                to_date=datetime(2020, 4, 19))
+    requests_mock.get('https://web.archive.org/cdx/search/cdx'
+                      '?url=https%3A%2F%2Fepa.gov%2F%2A'
+                      '&from=20200418000000&to=20200419000000'
+                      '&showResumeKey=true&resolveRevisits=true',
+                      [{'status_code': 200, 'text': bad_cdx_data}])
+    records = test_client.search('https://epa.gov/*',
+                                 from_date=datetime(2020, 4, 18),
+                                 to_date=datetime(2020, 4, 19))
 
-        assert 2 == len(list(records))
+    assert 2 == len(list(records))
 
 
-def test_search_handles_no_length_cdx_records(requests_mock):
+def test_search_handles_no_length_cdx_records(test_client, requests_mock):
     """
     The CDX index can contain a "-" in lieu of an actual length, which can't be
     parsed into an int. We should handle this.
@@ -246,24 +236,23 @@ def test_search_handles_no_length_cdx_records(requests_mock):
     with open(Path(__file__).parent / 'test_files' / 'zero_length_cdx.txt') as f:
         bad_cdx_data = f.read()
 
-    with WaybackClient() as client:
-        requests_mock.get('https://web.archive.org/cdx/search/cdx'
-                          '?url=www.cnn.com%2F%2A'
-                          '&matchType=domain&filter=statuscode%3A200'
-                          '&showResumeKey=true&resolveRevisits=true',
-                          [{'status_code': 200, 'text': bad_cdx_data}])
-        records = client.search('www.cnn.com/*',
-                                match_type="domain",
-                                filter_field="statuscode:200")
+    requests_mock.get('https://web.archive.org/cdx/search/cdx'
+                      '?url=www.cnn.com%2F%2A'
+                      '&matchType=domain&filter=statuscode%3A200'
+                      '&showResumeKey=true&resolveRevisits=true',
+                      [{'status_code': 200, 'text': bad_cdx_data}])
+    records = test_client.search('www.cnn.com/*',
+                                 match_type="domain",
+                                 filter_field="statuscode:200")
 
-        record_list = list(records)
-        assert 5 == len(record_list)
-        for record in record_list[:4]:
-            assert isinstance(record.length, int)
-        assert record_list[-1].length is None
+    record_list = list(records)
+    assert 5 == len(record_list)
+    for record in record_list[:4]:
+        assert isinstance(record.length, int)
+    assert record_list[-1].length is None
 
 
-def test_search_handles_bad_timestamp_cdx_records(requests_mock):
+def test_search_handles_bad_timestamp_cdx_records(test_client, requests_mock):
     """
     The CDX index can contain a timestamp with an invalid day "00", which can't be
     parsed into an timestamp. We should handle this.
@@ -274,27 +263,26 @@ def test_search_handles_bad_timestamp_cdx_records(requests_mock):
     with open(Path(__file__).parent / 'test_files' / 'bad_timestamp_cdx.txt') as f:
         bad_cdx_data = f.read()
 
-    with WaybackClient() as client:
-        requests_mock.get('https://web.archive.org/cdx/search/cdx'
-                          '?url=www.usatoday.com%2F%2A'
-                          '&matchType=domain&filter=statuscode%3A200'
-                          '&showResumeKey=true&resolveRevisits=true',
-                          [{'status_code': 200, 'text': bad_cdx_data}])
-        records = client.search('www.usatoday.com/*',
-                                match_type="domain",
-                                filter_field="statuscode:200")
+    requests_mock.get('https://web.archive.org/cdx/search/cdx'
+                      '?url=www.usatoday.com%2F%2A'
+                      '&matchType=domain&filter=statuscode%3A200'
+                      '&showResumeKey=true&resolveRevisits=true',
+                      [{'status_code': 200, 'text': bad_cdx_data}])
+    records = test_client.search('www.usatoday.com/*',
+                                 match_type="domain",
+                                 filter_field="statuscode:200")
 
-        record_list = list(records)
-        assert 5 == len(record_list)
+    record_list = list(records)
+    assert 5 == len(record_list)
 
-        # 00 month in 20000012170449 gets rewritten to 20001217044900
-        assert record_list[3].timestamp.month == 12
+    # 00 month in 20000012170449 gets rewritten to 20001217044900
+    assert record_list[3].timestamp.month == 12
 
-        # 00 day in 20000800241623 gets rewritten to 20000824162300
-        assert record_list[4].timestamp.day == 24
+    # 00 day in 20000800241623 gets rewritten to 20000824162300
+    assert record_list[4].timestamp.day == 24
 
 
-def test_search_parses_all_fields(requests_mock):
+def test_search_parses_all_fields(test_client, requests_mock):
     cdx_data = ' '.join([
         'com,cnn)/',
         '20100215131836',
@@ -307,269 +295,252 @@ def test_search_parses_all_fields(requests_mock):
         'ignored',
         'fields',
     ])
-    with WaybackClient() as client:
-        requests_mock.get('https://web.archive.org/cdx/search/cdx'
-                          '?url=http%3A%2F%2Fcnn.com'
-                          '&showResumeKey=true&resolveRevisits=true',
-                          [{'status_code': 200, 'text': cdx_data}])
-        record = next(client.search('http://cnn.com'))
+    requests_mock.get('https://web.archive.org/cdx/search/cdx'
+                      '?url=http%3A%2F%2Fcnn.com'
+                      '&showResumeKey=true&resolveRevisits=true',
+                      [{'status_code': 200, 'text': cdx_data}])
+    record = next(test_client.search('http://cnn.com'))
 
-        assert record.urlkey == 'com,cnn)/'
-        assert record.timestamp == datetime(2010, 2, 15, 13, 18, 36, tzinfo=timezone.utc)
-        assert record.original == 'http://www.cnn.com/'
-        assert record.mimetype == 'text/html'
-        assert record.statuscode == 200
-        assert record.digest == 'T6CDCO73TS77BY67HLKYFLHKT2APUM5Y'
-        assert record.length == 24186
+    assert record.urlkey == 'com,cnn)/'
+    assert record.timestamp == datetime(2010, 2, 15, 13, 18, 36, tzinfo=timezone.utc)
+    assert record.original == 'http://www.cnn.com/'
+    assert record.mimetype == 'text/html'
+    assert record.statuscode == 200
+    assert record.digest == 'T6CDCO73TS77BY67HLKYFLHKT2APUM5Y'
+    assert record.length == 24186
 
 
 @ia_vcr.use_cassette()
-def test_get_memento():
-    with WaybackClient() as client:
-        memento = client.get_memento('https://www.fws.gov/birds/',
-                                     timestamp=datetime(2017, 11, 24, 15, 13, 15))
-        assert 'https://www.fws.gov/birds/' == memento.url
-        assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
-        assert 'id_' == memento.mode
-        assert memento.headers == {
-            'Content-Type': 'text/html',
+def test_get_memento(test_client):
+    memento = test_client.get_memento('https://www.fws.gov/birds/',
+                                      timestamp=datetime(2017, 11, 24, 15, 13, 15))
+    assert 'https://www.fws.gov/birds/' == memento.url
+    assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
+    assert 'id_' == memento.mode
+    assert memento.headers == {
+        'Content-Type': 'text/html',
+        'Date': 'Fri, 24 Nov 2017 15:13:14 GMT',
+        'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
+        'Transfer-Encoding': 'chunked'
+    }
+    assert memento.links == {
+        'first memento': {
+            'datetime': 'Wed, 23 Mar 2005 15:53:00 GMT',
+            'rel': 'first memento',
+            'url': 'https://web.archive.org/web/20050323155300id_/http://www.fws.gov:80/birds'
+        },
+        'last memento': {
+            'datetime': 'Sun, 19 Mar 2023 07:02:36 GMT',
+            'rel': 'last memento',
+            'url': 'https://web.archive.org/web/20230319070236id_/http://fws.gov/birds/'
+        },
+        'prev memento': {
+            'datetime': 'Fri, 29 Sep 2017 00:27:12 GMT',
+            'rel': 'prev memento',
+            'url': 'https://web.archive.org/web/20170929002712id_/https://www.fws.gov/birds/'
+        },
+        'next memento': {
+            'datetime': 'Thu, 28 Dec 2017 22:21:43 GMT',
+            'rel': 'next memento',
+            'url': 'https://web.archive.org/web/20171228222143id_/https://www.fws.gov/birds/'
+        },
+        'memento': {
+            'datetime': 'Fri, 24 Nov 2017 15:13:15 GMT',
+            'rel': 'memento',
+            'url': 'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/'
+        },
+        'original': {
+            'rel': 'original',
+            'url': 'https://www.fws.gov/birds/'
+        },
+        'timegate': {
+            'rel': 'timegate',
+            'url': 'https://web.archive.org/web/https://www.fws.gov/birds/'
+        },
+        'timemap': {
+            'rel': 'timemap',
+            'type': 'application/link-format',
+            'url': 'https://web.archive.org/web/timemap/link/https://www.fws.gov/birds/'
+        },
+    }
+
+
+@ia_vcr.use_cassette()
+def test_get_memento_with_date_datetime(test_client):
+    memento = test_client.get_memento('https://www.fws.gov/birds/',
+                                      timestamp=date(2017, 11, 24),
+                                      exact=False)
+    assert 'https://www.fws.gov/birds/' == memento.url
+    assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
+    assert 'id_' == memento.mode
+
+
+@ia_vcr.use_cassette()
+def test_get_memento_with_string_datetime(test_client):
+    memento = test_client.get_memento('https://www.fws.gov/birds/',
+                                      timestamp='20171124151315')
+    assert 'https://www.fws.gov/birds/' == memento.url
+    assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
+    assert 'id_' == memento.mode
+
+
+@ia_vcr.use_cassette()
+def test_get_memento_with_inexact_string_datetime(test_client):
+    memento = test_client.get_memento('https://www.fws.gov/birds/',
+                                      timestamp='20171124151310',
+                                      exact=False)
+    assert 'https://www.fws.gov/birds/' == memento.url
+    assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
+    assert 'id_' == memento.mode
+
+
+@ia_vcr.use_cassette()
+def test_get_memento_handles_non_utc_datetime(test_client):
+    # Note the offset between requested_time and memento.timestamp.
+    requested_time = datetime(2017, 11, 24, 8, 13, 15,
+                              tzinfo=timezone(timedelta(hours=-7)))
+    memento = test_client.get_memento('https://www.fws.gov/birds/',
+                                      timestamp=requested_time)
+
+    assert 'https://www.fws.gov/birds/' == memento.url
+    assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
+    assert 'id_' == memento.mode
+
+
+@ia_vcr.use_cassette()
+def test_get_memento_with_invalid_datetime_type(test_client):
+    with pytest.raises(TypeError):
+        test_client.get_memento('https://www.fws.gov/birds/',
+                                timestamp=True)
+
+
+@ia_vcr.use_cassette()
+def test_get_memento_with_requires_datetime_with_regular_url(test_client):
+    with pytest.raises(TypeError):
+        test_client.get_memento('https://www.fws.gov/birds/')
+
+
+@ia_vcr.use_cassette()
+def test_get_memento_with_archive_url(test_client):
+    memento = test_client.get_memento(
+        'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/')
+
+    # Metadata About the Memento
+    assert 'https://www.fws.gov/birds/' == memento.url
+    assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
+    assert 'id_' == memento.mode
+    assert 'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/' == memento.memento_url
+    assert () == memento.history
+    assert () == memento.debug_history
+
+    # Archived HTTP Response
+    assert 200 == memento.status_code
+    assert memento.ok
+    assert not memento.is_redirect
+    assert {'Content-Type': 'text/html',
             'Date': 'Fri, 24 Nov 2017 15:13:14 GMT',
             'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
-            'Transfer-Encoding': 'chunked'
-        }
-        assert memento.links == {
-            'first memento': {
-                'datetime': 'Wed, 23 Mar 2005 15:53:00 GMT',
-                'rel': 'first memento',
-                'url': 'https://web.archive.org/web/20050323155300id_/http://www.fws.gov:80/birds'
-            },
-            'last memento': {
-                'datetime': 'Sun, 19 Mar 2023 07:02:36 GMT',
-                'rel': 'last memento',
-                'url': 'https://web.archive.org/web/20230319070236id_/http://fws.gov/birds/'
-            },
-            'prev memento': {
-                'datetime': 'Fri, 29 Sep 2017 00:27:12 GMT',
-                'rel': 'prev memento',
-                'url': 'https://web.archive.org/web/20170929002712id_/https://www.fws.gov/birds/'
-            },
-            'next memento': {
-                'datetime': 'Thu, 28 Dec 2017 22:21:43 GMT',
-                'rel': 'next memento',
-                'url': 'https://web.archive.org/web/20171228222143id_/https://www.fws.gov/birds/'
-            },
-            'memento': {
-                'datetime': 'Fri, 24 Nov 2017 15:13:15 GMT',
-                'rel': 'memento',
-                'url': 'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/'
-            },
-            'original': {
-                'rel': 'original',
-                'url': 'https://www.fws.gov/birds/'
-            },
-            'timegate': {
-                'rel': 'timegate',
-                'url': 'https://web.archive.org/web/https://www.fws.gov/birds/'
-            },
-            'timemap': {
-                'rel': 'timemap',
-                'type': 'application/link-format',
-                'url': 'https://web.archive.org/web/timemap/link/https://www.fws.gov/birds/'
-            },
-        }
+            'Transfer-Encoding': 'chunked'} == memento.headers
+    assert 'ISO-8859-1' == memento.encoding
+
+    content = get_file('fws-gov-birds.txt')
+    assert content == memento.content
+    assert content.decode('iso-8859-1') == memento.text
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_with_date_datetime():
-    with WaybackClient() as client:
-        memento = client.get_memento('https://www.fws.gov/birds/',
-                                     timestamp=date(2017, 11, 24),
-                                     exact=False)
-        assert 'https://www.fws.gov/birds/' == memento.url
-        assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
-        assert 'id_' == memento.mode
+def test_get_memento_with_cdx_record(test_client):
+    record = CdxRecord('xyz',
+                       datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc),
+                       'https://www.fws.gov/birds/',
+                       '-',
+                       200,
+                       'abc',
+                       100)
+    memento = test_client.get_memento(record)
+    assert 'https://www.fws.gov/birds/' == memento.url
+    assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
+    assert 'id_' == memento.mode
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_with_string_datetime():
-    with WaybackClient() as client:
-        memento = client.get_memento('https://www.fws.gov/birds/',
-                                     timestamp='20171124151315')
-        assert 'https://www.fws.gov/birds/' == memento.url
-        assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
-        assert 'id_' == memento.mode
+def test_get_memento_with_mode(test_client):
+    memento = test_client.get_memento('https://www.fws.gov/birds/',
+                                      timestamp=datetime(2017, 11, 24, 15, 13, 15),
+                                      mode=Mode.view)
+    assert '' == memento.mode
+    assert ('https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/'
+            == memento.memento_url)
+    assert ('https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/'
+            == memento.links['memento']['url'])
+    assert ('https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds'
+            == memento.links['first memento']['url'])
+
+    memento = test_client.get_memento('https://www.fws.gov/birds/',
+                                      timestamp=datetime(2017, 11, 24, 15, 13, 15))
+    assert 'id_' == memento.mode
+    assert ('https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/'
+            == memento.memento_url)
+    assert ('https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/'
+            == memento.links['memento']['url'])
+    assert ('https://web.archive.org/web/20050323155300id_/http://www.fws.gov:80/birds'
+            == memento.links['first memento']['url'])
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_with_inexact_string_datetime():
-    with WaybackClient() as client:
-        memento = client.get_memento('https://www.fws.gov/birds/',
-                                     timestamp='20171124151310',
-                                     exact=False)
-        assert 'https://www.fws.gov/birds/' == memento.url
-        assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
-        assert 'id_' == memento.mode
+def test_get_memento_with_mode_string(test_client):
+    memento = test_client.get_memento('https://www.fws.gov/birds/',
+                                      timestamp=datetime(2017, 11, 24, 15, 13, 15),
+                                      mode='id_')
+    assert 'id_' == memento.mode
+    assert 'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/' == memento.memento_url
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_handles_non_utc_datetime():
-    with WaybackClient() as client:
-        # Note the offset between requested_time and memento.timestamp.
-        requested_time = datetime(2017, 11, 24, 8, 13, 15,
-                                  tzinfo=timezone(timedelta(hours=-7)))
-        memento = client.get_memento('https://www.fws.gov/birds/',
-                                     timestamp=requested_time)
-
-        assert 'https://www.fws.gov/birds/' == memento.url
-        assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
-        assert 'id_' == memento.mode
+def test_get_memento_with_mode_boolean_is_not_allowed(test_client):
+    with pytest.raises(TypeError):
+        test_client.get_memento('https://www.fws.gov/birds/',
+                                timestamp=datetime(2017, 11, 24, 15, 13, 15),
+                                mode=True)
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_with_invalid_datetime_type():
-    with WaybackClient() as client:
-        with pytest.raises(TypeError):
-            client.get_memento('https://www.fws.gov/birds/',
-                               timestamp=True)
-
-
-@ia_vcr.use_cassette()
-def test_get_memento_with_requires_datetime_with_regular_url():
-    with WaybackClient() as client:
-        with pytest.raises(TypeError):
-            client.get_memento('https://www.fws.gov/birds/')
-
-
-@ia_vcr.use_cassette()
-def test_get_memento_with_archive_url():
-    with WaybackClient() as client:
-        memento = client.get_memento(
-            'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/')
-
-        # Metadata About the Memento
-        assert 'https://www.fws.gov/birds/' == memento.url
-        assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
-        assert 'id_' == memento.mode
-        assert 'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/' == memento.memento_url
-        assert () == memento.history
-        assert () == memento.debug_history
-
-        # Archived HTTP Response
-        assert 200 == memento.status_code
-        assert memento.ok
-        assert not memento.is_redirect
-        assert {'Content-Type': 'text/html',
-                'Date': 'Fri, 24 Nov 2017 15:13:14 GMT',
-                'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
-                'Transfer-Encoding': 'chunked'} == memento.headers
-        assert 'ISO-8859-1' == memento.encoding
-
-        content = get_file('fws-gov-birds.txt')
-        assert content == memento.content
-        assert content.decode('iso-8859-1') == memento.text
-
-
-@ia_vcr.use_cassette()
-def test_get_memento_with_cdx_record():
-    with WaybackClient() as client:
-        record = CdxRecord('xyz',
-                           datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc),
-                           'https://www.fws.gov/birds/',
-                           '-',
-                           200,
-                           'abc',
-                           100)
-        memento = client.get_memento(record)
-        assert 'https://www.fws.gov/birds/' == memento.url
-        assert datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc) == memento.timestamp
-        assert 'id_' == memento.mode
-
-
-@ia_vcr.use_cassette()
-def test_get_memento_with_mode():
-    with WaybackClient() as client:
-        memento = client.get_memento('https://www.fws.gov/birds/',
-                                     timestamp=datetime(2017, 11, 24, 15, 13, 15),
-                                     mode=Mode.view)
-        assert '' == memento.mode
-        assert ('https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/'
-                == memento.memento_url)
-        assert ('https://web.archive.org/web/20171124151315/https://www.fws.gov/birds/'
-                == memento.links['memento']['url'])
-        assert ('https://web.archive.org/web/20050323155300/http://www.fws.gov:80/birds'
-                == memento.links['first memento']['url'])
-
-        memento = client.get_memento('https://www.fws.gov/birds/',
-                                     timestamp=datetime(2017, 11, 24, 15, 13, 15))
-        assert 'id_' == memento.mode
-        assert ('https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/'
-                == memento.memento_url)
-        assert ('https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/'
-                == memento.links['memento']['url'])
-        assert ('https://web.archive.org/web/20050323155300id_/http://www.fws.gov:80/birds'
-                == memento.links['first memento']['url'])
-
-
-@ia_vcr.use_cassette()
-def test_get_memento_with_mode_string():
-    with WaybackClient() as client:
-        memento = client.get_memento('https://www.fws.gov/birds/',
-                                     timestamp=datetime(2017, 11, 24, 15, 13, 15),
-                                     mode='id_')
-        assert 'id_' == memento.mode
-        assert 'https://web.archive.org/web/20171124151315id_/https://www.fws.gov/birds/' == memento.memento_url
-
-
-@ia_vcr.use_cassette()
-def test_get_memento_with_mode_boolean_is_not_allowed():
-    with WaybackClient() as client:
-        with pytest.raises(TypeError):
-            client.get_memento('https://www.fws.gov/birds/',
-                               timestamp=datetime(2017, 11, 24, 15, 13, 15),
-                               mode=True)
-
-
-@ia_vcr.use_cassette()
-def test_get_memento_target_window():
-    with WaybackClient() as client:
-        memento = client.get_memento('https://www.fws.gov/birds/',
-                                     date(2017, 11, 1),
-                                     exact=False,
-                                     target_window=25 * 24 * 60 * 60)
-        assert memento.timestamp == datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc)
+def test_get_memento_target_window(test_client):
+    memento = test_client.get_memento('https://www.fws.gov/birds/',
+                                      date(2017, 11, 1),
+                                      exact=False,
+                                      target_window=25 * 24 * 60 * 60)
+    assert memento.timestamp == datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc)
 
 
 @ia_vcr.use_cassette('test_get_memento_target_window.yaml')
-def test_get_memento_timedelta_target_window():
-    with WaybackClient() as client:
-        memento = client.get_memento('https://www.fws.gov/birds/',
-                                     date(2017, 11, 1),
-                                     exact=False,
-                                     target_window=timedelta(days=25))
-        assert memento.timestamp == datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc)
+def test_get_memento_timedelta_target_window(test_client):
+    memento = test_client.get_memento('https://www.fws.gov/birds/',
+                                      date(2017, 11, 1),
+                                      exact=False,
+                                      target_window=timedelta(days=25))
+    assert memento.timestamp == datetime(2017, 11, 24, 15, 13, 15, tzinfo=timezone.utc)
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_raises_when_memento_is_outside_target_window():
+def test_get_memento_raises_when_memento_is_outside_target_window(test_client):
     with pytest.raises(MementoPlaybackError):
-        with WaybackClient() as client:
-            client.get_memento('https://www.fws.gov/birds/',
-                               date(2017, 11, 1),
-                               exact=False,
-                               target_window=24 * 60 * 60)
+        test_client.get_memento('https://www.fws.gov/birds/',
+                                date(2017, 11, 1),
+                                exact=False,
+                                target_window=24 * 60 * 60)
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_with_redirects():
-    with WaybackClient() as client:
-        memento = client.get_memento(
-            'https://web.archive.org/web/20180808094144id_/https://www.epa.gov/ghgreporting/san5779-factsheet')
-        assert len(memento.history) == 1        # memento redirects
-        assert len(memento.debug_history) == 2  # actual HTTP redirects
+def test_get_memento_with_redirects(test_client):
+    memento = test_client.get_memento(
+        'https://web.archive.org/web/20180808094144id_/https://www.epa.gov/ghgreporting/san5779-factsheet')
+    assert len(memento.history) == 1        # memento redirects
+    assert len(memento.debug_history) == 2  # actual HTTP redirects
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_with_path_based_redirects():
+def test_get_memento_with_path_based_redirects(test_client):
     """
     Most redirects in Wayback redirect to a complete URL, with headers like:
         Location: https://web.archive.org/web/20201027215555id_/https://www.whitehouse.gov/administration
@@ -577,15 +548,14 @@ def test_get_memento_with_path_based_redirects():
         Location: /web/20201027215555id_/https://www.whitehouse.gov/ostp/about/student/faqs
     This tests that we correctly handle the latter situation.
     """
-    with WaybackClient() as client:
-        memento = client.get_memento('https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs',
-                                     datetime(2020, 10, 27, 21, 55, 55))
-        assert len(memento.history) == 1
-        assert memento.url == memento.history[0].headers['Location']
+    memento = test_client.get_memento('https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs',
+                                      datetime(2020, 10, 27, 21, 55, 55))
+    assert len(memento.history) == 1
+    assert memento.url == memento.history[0].headers['Location']
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_with_schemeless_redirects():
+def test_get_memento_with_schemeless_redirects(test_client):
     """
     Most redirects in Wayback redirect to a complete URL, with headers like:
         Location: https://web.archive.org/web/20201027215555id_/https://www.whitehouse.gov/administration
@@ -593,129 +563,119 @@ def test_get_memento_with_schemeless_redirects():
         Location: //web.archive.org/web/20201102232816id_/https://www.census.gov/geo/gssi/
     This tests that we correctly handle the latter situation.
     """
-    with WaybackClient() as client:
-        memento = client.get_memento('https://www.census.gov/geography/gss-initiative.html',
-                                     datetime(2020, 11, 2, 23, 28, 16))
-        assert len(memento.history) == 1
-        assert memento.url == memento.history[0].headers['Location']
+    memento = test_client.get_memento('https://www.census.gov/geography/gss-initiative.html',
+                                      datetime(2020, 11, 2, 23, 28, 16))
+    assert len(memento.history) == 1
+    assert memento.url == memento.history[0].headers['Location']
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_raises_for_mementos_that_redirect_in_a_loop():
-    with WaybackClient() as client:
-        with pytest.raises(MementoPlaybackError):
-            client.get_memento(
-                'https://link.springer.com/article/10.1007/s00382-012-1331-2',
-                '20200925075402')
+def test_get_memento_raises_for_mementos_that_redirect_in_a_loop(test_client):
+    with pytest.raises(MementoPlaybackError):
+        test_client.get_memento(
+            'https://link.springer.com/article/10.1007/s00382-012-1331-2',
+            '20200925075402')
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_with_redirect_in_view_mode():
+def test_get_memento_with_redirect_in_view_mode(test_client):
     """
     Redirects in view mode respond with different headers, status codes, and
     bodies that other modes. They require special handling and testing.
     """
-    with WaybackClient() as client:
-        memento = client.get_memento(
-            'https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs',
-            timestamp='20201027215555',
-            mode=Mode.view)
-        assert len(memento.history) == 1        # memento redirects
-        assert len(memento.debug_history) == 2  # actual HTTP redirects
+    memento = test_client.get_memento(
+        'https://www.whitehouse.gov/administration/eop/ostp/about/student/faqs',
+        timestamp='20201027215555',
+        mode=Mode.view)
+    assert len(memento.history) == 1        # memento redirects
+    assert len(memento.debug_history) == 2  # actual HTTP redirects
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_should_fail_for_non_playbackable_mementos():
-    with WaybackClient() as client:
-        with pytest.raises(MementoPlaybackError):
-            client.get_memento('https://www.fws.gov/birds/', '20150509080314')
+def test_get_memento_should_fail_for_non_playbackable_mementos(test_client):
+    with pytest.raises(MementoPlaybackError):
+        test_client.get_memento('https://www.fws.gov/birds/', '20150509080314')
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_raises_blocked_error():
-    with WaybackClient() as client:
-        with pytest.raises(BlockedSiteError):
-            client.get_memento('https://nationalpost.com/health/', '20170929002712')
+def test_get_memento_raises_blocked_error(test_client):
+    with pytest.raises(BlockedSiteError):
+        test_client.get_memento('https://nationalpost.com/health/', '20170929002712')
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_raises_no_memento_error():
-    with WaybackClient() as client:
-        with pytest.raises(NoMementoError):
-            client.get_memento('https://this-is-not-real-url.whatever/',
-                               '20170929002712')
+def test_get_memento_raises_no_memento_error(test_client):
+    with pytest.raises(NoMementoError):
+        test_client.get_memento('https://this-is-not-real-url.whatever/',
+                                '20170929002712')
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_works_on_archived_rate_limit_responses():
-    with WaybackClient() as client:
-        memento = client.get_memento('http://www.reddit.com/r/PokemonGiveaway',
-                                     timestamp=datetime(2015, 1, 29, 3, 49, 4),
-                                     exact=True)
-        assert 'http://www.reddit.com/r/PokemonGiveaway' == memento.url
-        assert 429 == memento.status_code
+def test_get_memento_works_on_archived_rate_limit_responses(test_client):
+    memento = test_client.get_memento('http://www.reddit.com/r/PokemonGiveaway',
+                                      timestamp=datetime(2015, 1, 29, 3, 49, 4),
+                                      exact=True)
+    assert 'http://www.reddit.com/r/PokemonGiveaway' == memento.url
+    assert 429 == memento.status_code
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_follows_historical_redirects():
-    with WaybackClient() as client:
-        # In February 2020, https://www.epa.gov/climatechange redirected to:
-        #   https://www.epa.gov/sites/production/files/signpost/cc.html
-        #
-        # What should happen here under the hood:
-        # https://web.archive.org/web/20200201020357id_/http://epa.gov/climatechange
-        #   Is not a memento, and sends us to:
-        #   https://web.archive.org/web/20200201023757id_/https://www.epa.gov/climatechange
-        #     Which is a memento of a redirect to:
-        #     https://web.archive.org/web/20200201023757id_/https://www.epa.gov/sites/production/files/signpost/cc.html
-        #       ...which is not a memento, and redirects to:
-        #       https://web.archive.org/web/20200201024405id_/https://www.epa.gov/sites/production/files/signpost/cc.html
-        start_url = ('https://web.archive.org/web/20200201020357id_/'
-                     'http://epa.gov/climatechange')
-        target = ('https://web.archive.org/web/20200201024405id_/'
-                  'https://www.epa.gov/sites/production/files/signpost/cc.html')
-        memento = client.get_memento(start_url, exact=False)
-        assert 'https://www.epa.gov/sites/production/files/signpost/cc.html' == memento.url
-        assert target == memento.memento_url
-        assert len(memento.history) == 1
-        assert len(memento.debug_history) == 3
+def test_get_memento_follows_historical_redirects(test_client):
+    # In February 2020, https://www.epa.gov/climatechange redirected to:
+    #   https://www.epa.gov/sites/production/files/signpost/cc.html
+    #
+    # What should happen here under the hood:
+    # https://web.archive.org/web/20200201020357id_/http://epa.gov/climatechange
+    #   Is not a memento, and sends us to:
+    #   https://web.archive.org/web/20200201023757id_/https://www.epa.gov/climatechange
+    #     Which is a memento of a redirect to:
+    #     https://web.archive.org/web/20200201023757id_/https://www.epa.gov/sites/production/files/signpost/cc.html
+    #       ...which is not a memento, and redirects to:
+    #       https://web.archive.org/web/20200201024405id_/https://www.epa.gov/sites/production/files/signpost/cc.html
+    start_url = ('https://web.archive.org/web/20200201020357id_/'
+                 'http://epa.gov/climatechange')
+    target = ('https://web.archive.org/web/20200201024405id_/'
+              'https://www.epa.gov/sites/production/files/signpost/cc.html')
+    memento = test_client.get_memento(start_url, exact=False)
+    assert 'https://www.epa.gov/sites/production/files/signpost/cc.html' == memento.url
+    assert target == memento.memento_url
+    assert len(memento.history) == 1
+    assert len(memento.debug_history) == 3
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_follow_redirects_does_not_follow_historical_redirects():
-    with WaybackClient() as client:
-        # In February 2020, https://www.epa.gov/climatechange redirected to:
-        #   https://www.epa.gov/sites/production/files/signpost/cc.html
-        #
-        # What should happen here under the hood:
-        # https://web.archive.org/web/20200201020357id_/http://epa.gov/climatechange
-        #   Is not a memento, and sends us to:
-        #   https://web.archive.org/web/20200201023757id_/https://www.epa.gov/climatechange
-        #     Which is a memento of a redirect. Because follow_redirects=False,
-        #     we should *not* follow it to:
-        #     https://web.archive.org/web/20200201023757id_/https://www.epa.gov/sites/production/files/signpost/cc.html
-        #       ...and then to:
-        #       https://web.archive.org/web/20200201024405id_/https://www.epa.gov/sites/production/files/signpost/cc.html
-        start_url = ('https://web.archive.org/web/20200201020357id_/'
-                     'http://epa.gov/climatechange')
-        target = ('https://web.archive.org/web/20200201023757id_/'
-                  'https://www.epa.gov/climatechange')
-        memento = client.get_memento(start_url, exact=False, follow_redirects=False)
-        assert 'https://www.epa.gov/climatechange' == memento.url
-        assert target == memento.memento_url
-        assert memento.status_code == 301
-        assert 'https://www.epa.gov/sites/production/files/signpost/cc.html' == memento.headers['Location']
-        assert len(memento.history) == 0
-        assert len(memento.debug_history) == 1
+def test_get_memento_follow_redirects_does_not_follow_historical_redirects(test_client):
+    # In February 2020, https://www.epa.gov/climatechange redirected to:
+    #   https://www.epa.gov/sites/production/files/signpost/cc.html
+    #
+    # What should happen here under the hood:
+    # https://web.archive.org/web/20200201020357id_/http://epa.gov/climatechange
+    #   Is not a memento, and sends us to:
+    #   https://web.archive.org/web/20200201023757id_/https://www.epa.gov/climatechange
+    #     Which is a memento of a redirect. Because follow_redirects=False,
+    #     we should *not* follow it to:
+    #     https://web.archive.org/web/20200201023757id_/https://www.epa.gov/sites/production/files/signpost/cc.html
+    #       ...and then to:
+    #       https://web.archive.org/web/20200201024405id_/https://www.epa.gov/sites/production/files/signpost/cc.html
+    start_url = ('https://web.archive.org/web/20200201020357id_/'
+                 'http://epa.gov/climatechange')
+    target = ('https://web.archive.org/web/20200201023757id_/'
+              'https://www.epa.gov/climatechange')
+    memento = test_client.get_memento(start_url, exact=False, follow_redirects=False)
+    assert 'https://www.epa.gov/climatechange' == memento.url
+    assert target == memento.memento_url
+    assert memento.status_code == 301
+    assert 'https://www.epa.gov/sites/production/files/signpost/cc.html' == memento.headers['Location']
+    assert len(memento.history) == 0
+    assert len(memento.debug_history) == 1
 
 
 @ia_vcr.use_cassette()
-def test_get_memento_returns_memento_with_accurate_url():
-    with WaybackClient() as client:
-        # This memento is actually captured from 'https://www.', not 'http://'.
-        memento = client.get_memento('http://fws.gov/',
-                                     timestamp='20171124143728')
-        assert memento.url == 'https://www.fws.gov/'
+def test_get_memento_returns_memento_with_accurate_url(test_client):
+    # This memento is actually captured from 'https://www.', not 'http://'.
+    memento = test_client.get_memento('http://fws.gov/',
+                                      timestamp='20171124143728')
+    assert memento.url == 'https://www.fws.gov/'
 
 
 def return_timeout(self, *args, **kwargs) -> requests.Response:


### PR DESCRIPTION
fix: #190 

### Summary

Disable rate limiting in tests that use VCR cassettes and mocked responses by introducing a shared pytest fixture.

### Changes

- Added a test_client fixture in conftest.py with rate limits disabled
- Updated tests to use the shared client when using VCR (@ia_vcr.use_cassette()) and requests_mock
- Left rate-limit-specific tests unchanged to preserve existing behavior

### Result

- Faster test execution
- Cleaner and more consistent test setup