### PR TITLE
Move pytest config into `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ test = [
     "codecov",
     "coverage",
     "requests-mock",
-    "pytest",
+    "pytest >=8.3.5",
     "vcrpy",
 ]
 
@@ -77,3 +77,7 @@ exclude = ["src/wayback/tests/*"]
 
 [tool.check-wheel-contents]
 toplevel = "wayback"
+
+[tool.pytest.ini_options]
+testpaths = ["src/wayback/tests"]
+python_files = ["test*.py"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-testpaths = wayback/tests/
-python_files = test*.py


### PR DESCRIPTION
This also puts a minimum bound on pytest versions (the latest version that still supports Python 3.8).

This is a part of #185.