### PR TITLE
Fix Circle cache always breaking on Python updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
                   pip install .[docs]
 
       - save_cache:
-          key: cache_v11-wayback-{{ checksum "/home/circleci/.pyenv/version" }}-{{ arch }}-{{ checksum "pyproject.toml" }}
+          key: cache_v11-wayback-{{ checksum "/home/circleci/.tmp-python-version" }}-{{ arch }}-{{ checksum "pyproject.toml" }}
           paths:
             - ~/venv
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,9 @@ commands:
       - run:
           name: Get Python Version
           command: |
-            python --version | cut -d ' ' -f2 > /home/circleci/.tmp-python-version
+            python \
+              -c 'import sys;print(sys.version.split(" ")[0] + ("t" if "free-threading" in sys.version else ""))' \
+              > /home/circleci/.tmp-python-version
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,6 @@ commands:
   setup_pip:
     description: "Set Up Dependencies"
     parameters:
-      python-version:
-        type: string
       urllib3-version:
         type: string
         default: "2.0"
@@ -24,10 +22,15 @@ commands:
         type: boolean
         default: false
     steps:
+      - run:
+          name: Get Python Version
+          command: |
+            python --version | cut -d ' ' -f2 > /home/circleci/.tmp-python-version
+
       - restore_cache:
           keys:
-            - cache_v11-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "pyproject.toml" }}
-            - cache_v11-wayback-<< parameters.python-version >>-{{ arch }}-
+            - cache_v11-wayback-{{ checksum "/home/circleci/.tmp-python-version" }}-{{ arch }}-{{ checksum "pyproject.toml" }}
+            - cache_v11-wayback-{{ checksum "/home/circleci/.tmp-python-version" }}-{{ arch }}-
 
       - run:
           name: Install Dependencies
@@ -60,7 +63,7 @@ commands:
                   pip install .[docs]
 
       - save_cache:
-          key: cache_v11-wayback-<< parameters.python-version >>-{{ arch }}-{{ checksum "pyproject.toml" }}
+          key: cache_v11-wayback-{{ checksum "/home/circleci/.pyenv/version" }}-{{ arch }}-{{ checksum "pyproject.toml" }}
           paths:
             - ~/venv
 
@@ -81,7 +84,6 @@ jobs:
     steps:
       - checkout
       - setup_pip:
-          python-version: << parameters.python-version >>
           urllib3-version: << parameters.urllib3-version >>
 
       - run:
@@ -102,7 +104,6 @@ jobs:
     steps:
       - checkout
       - setup_pip:
-          python-version: "<< pipeline.parameters.primary-python-version >>"
           install-dev: true
       - run:
           name: Code linting
@@ -117,7 +118,6 @@ jobs:
     steps:
       - checkout
       - setup_pip:
-          python-version: "<< pipeline.parameters.primary-python-version >>"
           install-dev: true
       - run:
           name: Type checking
@@ -137,7 +137,6 @@ jobs:
     steps:
       - checkout
       - setup_pip:
-          python-version: "<< pipeline.parameters.primary-python-version >>"
           install-docs: true
       - run:
           name: Build docs


### PR DESCRIPTION
We have a long-standing and annoying problem where patch updates to Python (e.g. 3.14.4 → 3.14.5) break our builds. This aims to fix it.

The problem is that we cache the Python virtual environment, which includes references, symlinks, etc. to the system’s Python. Since we only request Python via its minor version (e.g. 3.14), Circle always gives us the latest actual release of that version (e.g. yesterday it might have been 3.14.4, today it may have been 3.14.5). But when the actual, concrete Python version changes, it breaks all the references in the virtualenv.

This solves the problem by baking the full Python version we’re running on (e.g. `3.14.5`) into cache key instead of just using the minor version we requested (e.g. `3.14`). So the cache key will always change when the patch release of Python changes.