### PR TITLE
Tell git not to mess with test data on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,4 @@
 *.py diff=python
 
 # Treat test data as binary so git does not change line endings or other bytes.
-src/wayback/tests/test_files/* binary
+src/wayback/tests/test_files/* -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,9 @@
 .git_archival.txt  export-subst
 *.py diff=python
 
-# Don't treat test data text so git does not change line endings or other bytes.
+# Don't treat test data as text. Git will change some features of text files
+# when checking out and committing (e.g. line endings on Windows), but the test
+# data needs to always stay the same, byte for byte.
+# We specify these files as "not text" instead of binary so they show up in
+# `git diff` and similar commands.
 src/wayback/tests/test_files/* -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,4 @@
 *.py diff=python
 
 # Treat test data as binary so git does not change line endings or other bytes.
-test_files/* binary
+src/wayback/tests/test_files/* binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 .git_archival.txt  export-subst
 *.py diff=python
+
+# Treat test data as binary so git does not change line endings or other bytes.
+test_files/* binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 .git_archival.txt  export-subst
 *.py diff=python
 
-# Treat test data as binary so git does not change line endings or other bytes.
+# Don't treat test data text so git does not change line endings or other bytes.
 src/wayback/tests/test_files/* -text


### PR DESCRIPTION
On Windows, git will automatically change the line endings on text files. Usually that’s a useful convenience, but our test data needs to have exact bytes that do not change. This marks those files as non-text so git doesn’t mess with them and cause testing issues. (We use non-text instead of binary so that we can still get nice diffs!)

Fixes #197.