### PR TITLE
Mark test fixtures as binary so they check out byte-for-byte on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 .git_archival.txt  export-subst
 *.py diff=python
+
+# Test fixtures must be checked out byte-for-byte (no line ending conversion)
+# so that byte-equality assertions against memento responses pass on Windows.
+src/wayback/tests/test_files/** binary


### PR DESCRIPTION
## Summary

Fixes #197.

On Windows, git's default `core.autocrlf=true` converts LF to CRLF when checking out text files. The `test_get_memento_with_archive_url` test reads `fws-gov-birds.txt` in binary mode (`'rb'`) and compares it byte-for-byte against a memento response from the VCR cassette, so the line-ending conversion breaks the assertion.

This adds an entry to `.gitattributes` marking everything under `src/wayback/tests/test_files/` as `binary`, so git preserves the on-disk bytes across platforms. The other test fixtures in that directory (`*_cdx.txt`) are read in text mode and Python normalizes line endings on read, so they don't need the fix, but treating the whole directory uniformly avoids the same trap for any test fixture added later.

## Test plan

Verified on Windows 11 / Python 3.14:

- [x] `pytest src/wayback/tests/test_client.py::test_get_memento_with_archive_url` passes after re-checking out the file with the new attributes applied
- [x] Full suite passes: `pytest src/wayback/tests/` — 67/67 pass