### PR TITLE
Defer some removals to v0.6.0

### DIFF
--- a/src/wayback/_client.py
+++ b/src/wayback/_client.py
@@ -709,7 +709,7 @@ class WaybackClient(_utils.DepthCountedContext):
             warn(
                 'The `matchType` parameter for search() was renamed to '
                 '`match_type`. Support for the old name will be removed in '
-                'wayback v0.5.0; please update your code.',
+                'wayback v0.6.0; please update your code.',
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -718,7 +718,7 @@ class WaybackClient(_utils.DepthCountedContext):
             warn(
                 'The `fastLatest` parameter for search() was renamed to '
                 '`fast_latest`. Support for the old name will be removed in '
-                'wayback v0.5.0; please update your code.',
+                'wayback v0.6.0; please update your code.',
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -727,7 +727,7 @@ class WaybackClient(_utils.DepthCountedContext):
             warn(
                 'The `resolveRevisits` parameter for search() was renamed to '
                 '`resolve_revisits`. Support for the old name will be removed '
-                'in wayback v0.5.0; please update your code.',
+                'in wayback v0.6.0; please update your code.',
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -922,7 +922,7 @@ class WaybackClient(_utils.DepthCountedContext):
             warn(
                 'The `datetime` parameter for get_memento() was renamed to '
                 '`timestamp`. Support for the old name will be removed '
-                'in wayback v0.5.0; please update your code.',
+                'in wayback v0.6.0; please update your code.',
                 DeprecationWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
We originally planned to remove some of these older arguments to `search()` and `get_memento()` in v0.5.0, but that was when we thought we'd have other big deal changes in that release. Instead, those changes have been pushed to v0.6.0 and the breaking changes in v0.5.0 are limited to unusual cases and shouldn't affect most users. So we're deferring these removals as well to limit v0.5.0 breakage and keep them with the bigger breakage coming in v0.6.0.

Part of #202.