### PR TITLE
Update search/timemap rate limits

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -2,6 +2,12 @@
 Release History
 ===============
 
+(In Development)
+----------------
+
+The ``timemap_calls_per_second`` parameter for :class:`WaybackSession` has been deprecated and will be removed in v0.6.0. The API it handled rate limiting for is now the same service and shares the same rate limiting as the one handled by ``search_calls_per_second``. You should now *only* use ``search_calls_per_second``.
+
+
 v0.5.0 (2026-05-22)
 -------------------
 

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -5,7 +5,9 @@ Release History
 (In Development)
 ----------------
 
-The ``timemap_calls_per_second`` parameter for :class:`WaybackSession` has been deprecated and will be removed in v0.6.0. The API it handled rate limiting for is now the same service and shares the same rate limiting as the one handled by ``search_calls_per_second``. You should now *only* use ``search_calls_per_second``.
+The ``timemap_calls_per_second`` parameter for :class:`wayback.WaybackSession` has been deprecated and will be removed in v0.6.0. The API it handled rate limiting for is now the same service and shares the same rate limiting as the one handled by ``search_calls_per_second``. You should now *only* use ``search_calls_per_second``.
+
+The default value for ``search_calls_per_second`` has also been reduced to 0.4 in order to match the actual rate limits the Wayback Machine is currently enforcing.
 
 
 v0.5.0 (2026-05-22)

--- a/src/wayback/_client.py
+++ b/src/wayback/_client.py
@@ -73,8 +73,7 @@ URL_ISH = re.compile(r'^[\w+\-]+://[^/?=&]+\.\w\w+(:\d+)?(/|$)')
 
 # Global default rate limits for various endpoints. Internet Archive folks have
 # asked us to set the defaults at 80% of the hard limits.
-DEFAULT_CDX_RATE_LIMIT = _utils.RateLimit(0.8 * 60 / 60)
-DEFAULT_TIMEMAP_RATE_LIMIT = _utils.RateLimit(0.8 * 100 / 60)
+DEFAULT_CDX_RATE_LIMIT = _utils.RateLimit(0.8 * 30 / 60)
 DEFAULT_MEMENTO_RATE_LIMIT = _utils.RateLimit(0.8 * 600 / 60)
 
 # If a rate limit response (i.e. a response with status == 429) does not
@@ -310,7 +309,7 @@ class WaybackSession(_utils.DisableAfterCloseSession, requests.Session):
     user_agent : str, optional
         A custom user-agent string to use in all requests. Defaults to:
         `wayback/{version} (+https://github.com/edgi-govdata-archiving/wayback)`
-    search_calls_per_second : wayback.RateLimit or int or float, default: 0.8
+    search_calls_per_second : wayback.RateLimit or int or float, default: 0.4
         The maximum number of calls per second made to the CDX search API.
         To disable the rate limit, set this to 0.
 
@@ -328,16 +327,10 @@ class WaybackSession(_utils.DisableAfterCloseSession, requests.Session):
         single :class:`wayback.RateLimit` instance and pass it to each
         ``WaybackSession`` instance. If you do not set a limit, the default
         limit is shared globally across all sessions.
-    timemap_calls_per_second : wayback.RateLimit or int or float, default: 1.33
-        The maximum number of calls per second made to the timemap API (the
-        Wayback Machine's new, beta CDX search is part of the timemap API).
-        To disable the rate limit, set this to 0.
-
-        To have multiple sessions share a rate limit (so requests made by one
-        session count towards the limit of the other session), use a
-        single :class:`wayback.RateLimit` instance and pass it to each
-        ``WaybackSession`` instance. If you do not set a limit, the default
-        limit is shared globally across all sessions.
+    timemap_calls_per_second : wayback.RateLimit or int or float, default: 0.4
+        **This parameter is deprecated.** The service it set a rate limit for
+        now shares its limits with the one covered by
+        ``search_calls_per_second``. Set that parameter instead.
     """
 
     # It seems Wayback sometimes produces 500 errors for transient issues, so
@@ -357,7 +350,7 @@ class WaybackSession(_utils.DisableAfterCloseSession, requests.Session):
         user_agent=None,
         search_calls_per_second=DEFAULT_CDX_RATE_LIMIT,
         memento_calls_per_second=DEFAULT_MEMENTO_RATE_LIMIT,
-        timemap_calls_per_second=DEFAULT_TIMEMAP_RATE_LIMIT,
+        timemap_calls_per_second=None,
     ):
         super().__init__()
         self.retries = retries
@@ -369,9 +362,21 @@ class WaybackSession(_utils.DisableAfterCloseSession, requests.Session):
             ),
             'Accept-Encoding': 'gzip, deflate',
         }
+        search_calls_per_second = _utils.RateLimit.make_limit(search_calls_per_second)
+        if timemap_calls_per_second is None:
+            timemap_calls_per_second = search_calls_per_second
+        else:
+            warn(
+                'The `timemap_calls_per_second` parameter of WaybackSession() '
+                'will be removed in wayback v0.6.0. The service it handled '
+                'now shares rate limiting with `search_calls_per_second`.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         self.rate_limts = {
-            '/web/timemap': _utils.RateLimit.make_limit(timemap_calls_per_second),
-            '/cdx': _utils.RateLimit.make_limit(search_calls_per_second),
+            '/web/timemap': timemap_calls_per_second,
+            '/cdx': search_calls_per_second,
             # The memento limit is actually a generic Wayback limit.
             '/': _utils.RateLimit.make_limit(memento_calls_per_second),
         }

--- a/src/wayback/_client.py
+++ b/src/wayback/_client.py
@@ -49,14 +49,6 @@ from .exceptions import (
 logger = logging.getLogger(__name__)
 
 CDX_SEARCH_URL = 'https://web.archive.org/cdx/search/cdx'
-# This /web/timemap URL has newer features, but has other bugs and doesn't
-# support some features, like resume keys (for paging). It ignores robots.txt,
-# while /cdx/search obeys robots.txt (for now). It also has different/extra
-# columns. See
-# https://github.com/internetarchive/wayback/blob/bd205b9b26664a6e2ea3c0c2a8948f0dc6ff4519/wayback-cdx-server/src/main/java/org/archive/cdxserver/format/CDX11Format.java#L13-L17  # noqa
-# NOTE: the `length` and `robotflags` fields appear to always be empty
-# TODO: support new/upcoming CDX API
-# CDX_SEARCH_URL = 'https://web.archive.org/web/timemap/cdx'
 
 REDUNDANT_HTTP_PORT = re.compile(r'^(http://[^:/]+):80(.*)$')
 REDUNDANT_HTTPS_PORT = re.compile(r'^(https://[^:/]+):443(.*)$')

--- a/src/wayback/tests/conftest.py
+++ b/src/wayback/tests/conftest.py
@@ -5,11 +5,13 @@ from wayback._utils import RateLimit
 
 @pytest.fixture
 def test_client():
-    session = WaybackSession(
-        search_calls_per_second=RateLimit(0),
-        memento_calls_per_second=RateLimit(0),
-        timemap_calls_per_second=RateLimit(0),
-    )
+    session = None
+    with pytest.warns(DeprecationWarning, match='timemap_calls_per_second'):
+        session = WaybackSession(
+            search_calls_per_second=RateLimit(0),
+            memento_calls_per_second=RateLimit(0),
+            timemap_calls_per_second=RateLimit(0),
+        )
     client = WaybackClient(session)
     yield client
     client.close()

--- a/src/wayback/tests/test_client.py
+++ b/src/wayback/tests/test_client.py
@@ -785,7 +785,7 @@ class TestWaybackSession:
                 next(client.search('zew.de'))
         duration_with_limits_custom = time.time() - start_time
 
-        assert 2.4 <= duration_with_limits <= 2.6
+        assert 4.8 <= duration_with_limits <= 5.2
         assert 0.0 <= duration_without_limits <= 0.05
         assert 0.0 <= duration_with_limits_custom <= 1.05
 


### PR DESCRIPTION
The `/cdx/search/cdx` and `/web/timemap/*` endpoints used to be separate, but are now one service with one shared rate limiting pool. This deprecates the `timemap_calls_per_second` option to `WaybackSession` since it is no longer relevant.

This also updates the default rate limit for both endpoints to reflect the actual rate limit Internet Archive is currently applying.

Fixes #206.