### PR TITLE
Pin GH actions versions and update w/ Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
   allow:
     - dependency-type: "development"
   open-pull-requests-limit: 10
+
+- package-ecosystem: 'github-actions'
+  directory: '/'
+  schedule:
+    interval: 'monthly'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,11 +14,11 @@ jobs:
   dist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
 
   publish:
     needs: [dist]
@@ -29,10 +29,10 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: Packages
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 


### PR DESCRIPTION
We've got a few actions that are a bit out of date. I thought I'd had Dependabot set up for actions, but apparently not! This also switches to versioning via commit hashes for better security.